### PR TITLE
Fix OCTGN XML export

### DIFF
--- a/src/AppBundle/Resources/views/Export/octgn.xml.twig
+++ b/src/AppBundle/Resources/views/Export/octgn.xml.twig
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<deck game="30c200c9-6c98-49a4-a293-106c06295c05" sleeveid="0">
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf" sleeveid="0">
   <section name="Investigator" shared="False">
     <card qty="1" id="{{ deck.investigator.octgnId }}">{{ deck.investigator.name }}</card>
   </section>
-  <section name="Assets" shared="False">
+  <section name="Asset" shared="False">
 {% for slot in deck.slots_by_type.asset %}
     <card qty="{{ slot.quantity }}" id="{{ slot.card.octgnId }}">{{ slot.card.name }}</card>
 {% endfor %}
   </section>
-  <section name="Events" shared="False">
+  <section name="Event" shared="False">
 {% for slot in deck.slots_by_type.event %}
     <card qty="{{ slot.quantity }}" id="{{ slot.card.octgnId }}">{{ slot.card.name }}</card>
 {% endfor %}
   </section>
-  <section name="Skills" shared="False">
+  <section name="Skill" shared="False">
 {% for slot in deck.slots_by_type.skill %}
     <card qty="{{ slot.quantity }}" id="{{ slot.card.octgnId }}">{{ slot.card.name }}</card>
 {% endfor %}
   </section>
-  <section name="Treachery" shared="False">
+  <section name="Weakness" shared="False">
 {% for slot in deck.slots_by_type.treachery %}
     <card qty="{{ slot.quantity }}" id="{{ slot.card.octgnId }}">{{ slot.card.name }}</card>
 {% endfor %}

--- a/src/AppBundle/Resources/views/Export/octgn.xml.twig
+++ b/src/AppBundle/Resources/views/Export/octgn.xml.twig
@@ -22,8 +22,6 @@
 {% for slot in deck.slots_by_type.treachery %}
     <card qty="{{ slot.quantity }}" id="{{ slot.card.octgnId }}">{{ slot.card.name }}</card>
 {% endfor %}
-  </section>
-  <section name="Enemy" shared="False">
 {% for slot in deck.slots_by_type.enemy %}
     <card qty="{{ slot.quantity }}" id="{{ slot.card.octgnId }}">{{ slot.card.name }}</card>
 {% endfor %}


### PR DESCRIPTION
This fixes several elements for compatibility with the OCTGN module. It does not fix the investigator card. With this patch, you can import the deck into the OCTGN deck builder, add the actual investigator card, save and play.