### PR TITLE
Convert deck action oauth2 endpoints to Arkham

### DIFF
--- a/src/AppBundle/Controller/Oauth2Controller.php
+++ b/src/AppBundle/Controller/Oauth2Controller.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use AppBundle\Entity\Deck;
+use AppBundle\Entity\Deckslot;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Oauth2Controller extends Controller
@@ -25,26 +26,26 @@ class Oauth2Controller extends Controller
 	{
 		$response = new Response();
 		$response->headers->add(array('Access-Control-Allow-Origin' => '*'));
-		
+
 		/* @var $decks \AppBundle\Entity\Deck[] */
 		$decks = $this->getDoctrine()->getRepository('AppBundle:Deck')->findBy(['user' => $this->getUser()]);
 
 		$dateUpdates = array_map(function ($deck) {
 			return $deck->getDateUpdate();
 		}, $decks);
-		
+
 		$response->setLastModified(max($dateUpdates));
 		if ($response->isNotModified($request)) {
 			return $response;
 		}
 
 		$content = json_encode($decks);
-		
+
 		$response->headers->set('Content-Type', 'application/json');
 		$response->setContent($content);
 		return $response;
 	}
-	
+
 
 	/**
 	 * Get the description of one Deck of the authenticated user
@@ -68,27 +69,294 @@ class Oauth2Controller extends Controller
 	{
 		$response = new Response();
 		$response->headers->add(array('Access-Control-Allow-Origin' => '*'));
-		
+
 		/* @var $deck \AppBundle\Entity\Deck */
 		$deck = $this->getDoctrine()->getRepository('AppBundle:Deck')->find($id);
 
-		if($deck->getUser()->getId() !== $this->getUser()->getId())
-		{
+		if($deck->getUser()->getId() !== $this->getUser()->getId() &&
+			!$deck->getUser()->getIsShareDecks()) {
 			throw $this->createAccessDeniedException("Access denied to this object.");
-		}
-		
-		$response->setLastModified($deck->getDateUpdate());
-		if ($response->isNotModified($request)) {
-			return $response;
 		}
 
 		$content = json_encode($deck);
-		
+
 		$response->headers->set('Content-Type', 'application/json');
 		$response->setContent($content);
 		return $response;
 	}
-	
+
+	/**
+	 * Create a new deck for the authenticated user.
+	 * An investigator is required, and the deck will be created empty with only
+	 * the 'required' cards for that investigator.
+	 * If successful, id of new Deck is in the msg
+	 *
+	 * @ApiDoc(
+	 *  section="Deck",
+	 *  resource=true,
+	 *  description="Create a New Deck",
+	 *  parameters={
+	 *      {"name"="investigator", "dataType"="string", "required"=true, "description"="Code of the investigator card."},
+	 *      {"name"="name", "dataType"="string", "required"=false, "description"="Name of the Deck. A default name will be generated if it is not specified."},
+	 *  },
+	 * )
+	 * @param Request $request
+	 */
+	public function newDeckAction(Request $request)
+	{
+		/* @var $em \Doctrine\ORM\EntityManager */
+		$em = $this->getDoctrine()->getManager();
+
+		$investigator = false;
+		$investigator_code = filter_var($request->get('investigator'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+		if ($investigator_code && $card = $em->getRepository('AppBundle:Card')->findOneBy(["code" => $investigator_code])){
+			$investigator = $card = $em->getRepository('AppBundle:Card')->findOneBy(["code" => $investigator_code]);
+		}
+
+		if (!$investigator) {
+			return new JsonResponse([
+				'success' => FALSE,
+				'msg' => "investigator is required to build a new deck."
+			]);
+		}
+
+		$tags = [ $investigator->getFaction()->getCode() ];
+		$cards_to_add = [];
+
+		// Parse deck requirements and pre-fill deck with needed cards
+		if ($investigator->getDeckRequirements()){
+			$deck_requirements = $this->get('DeckValidationHelper')->parseReqString($investigator->getDeckRequirements());
+			if (isset($deck_requirements['card']) && $deck_requirements['card']){
+				foreach($deck_requirements['card'] as $card_code => $alternates){
+					if ($card_code){
+						$card_to_add = $em->getRepository('AppBundle:Card')->findOneBy(array("code" => $card_code));
+						if ($card_to_add){
+							$cards_to_add[] = $card_to_add;
+						}
+					}
+				}
+			}
+
+			// add random deck requirements here
+			// should add a flag so the user can choose to add these or not
+			if (isset($deck_requirements['random']) && $deck_requirements['random']){
+				foreach($deck_requirements['random'] as $random){
+					if (isset($random['target']) && $random['target']){
+						if ($random['target'] === "subtype"){
+							$subtype = $em->getRepository('AppBundle:Subtype')->findOneBy(array("code" => $random['value']));
+							//$valid_targets = $em->getRepository('AppBundle:Card')->findBy(array("subtype" => $subtype->getId() ));
+							$valid_targets = $em->getRepository('AppBundle:Card')->findBy(array("name" => "Random Basic Weakness" ));
+							//print_r($subtype->getId());
+							if ($valid_targets){
+								$key = array_rand($valid_targets);
+								// should disable adding random weakness
+								$cards_to_add[] = $valid_targets[$key];
+							}
+						}
+					}
+				}
+			}
+		}
+
+		$pack = $investigator->getPack();
+		$name = filter_var($request->get('name'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+		if(!$name) {
+			// Set a default name if one was not provided.
+			$name = sprintf("%s", $investigator->getName());
+			if ($investigator->getFaction()->getCode() == "guardian"){
+				$name = sprintf("The Adventures of %s", $investigator->getName());
+			} else if ($investigator->getFaction()->getCode() == "seeker"){
+				$name = sprintf("%s Investigates", $investigator->getName());
+			} else if ($investigator->getFaction()->getCode() == "mystic"){
+				$name = sprintf("The %s Mysteries", $investigator->getName());
+			} else if ($investigator->getFaction()->getCode() == "rogue"){
+				$name = sprintf("The %s Job", $investigator->getName());
+			} else if ($investigator->getFaction()->getCode() == "survivor"){
+				$name = sprintf("%s on the Road", $investigator->getName());
+			}
+		}
+
+		$deck = new Deck();
+		// Make most of these fields empty by default, they can be set later.
+		$deck->setDescriptionMd("");
+		$deck->setCharacter($investigator);
+		$deck->setLastPack($pack);
+		$deck->setName($name);
+		$deck->setProblem('too_few_cards');
+		$deck->setTags(join(' ', array_unique($tags)));
+		$deck->setUser($this->getUser());
+
+		foreach ( $cards_to_add as $card) {
+			$slot = new Deckslot ();
+			$slot->setQuantity ( $card->getDeckLimit() );
+			$slot->setCard ( $card );
+			$slot->setDeck ( $deck );
+			//$slot->setIgnoreDeckRestrictions ( true );
+			$deck->addSlot ( $slot );
+		}
+		$em->persist($deck);
+		$em->flush();
+
+		// Return a successful deck with just the required cards.
+		return new JsonResponse([
+				'success' => TRUE,
+				'msg' => $deck->getId()
+		]);
+	}
+
+	/**
+	 * Upgrade a deck of the authenticated user. Takes a parameter for the amount of XP earned + a list of exiled cards.
+	 * This also serves to lock changes so that future card swaps are properly accounted for in the campaign XP.
+	 * If successful, the id of the new Deck is in the msg.
+	 *
+	 * @ApiDoc(
+	 *  section="Deck",
+	 *  resource=true,
+	 *  description="Upgrade One Deck",
+	 *  requirements={
+	 *      {
+	 *          "name"="id",
+	 *          "dataType"="integer",
+	 *          "requirement"="\d+",
+	 *          "description"="The numeric identifier of the Deck to update.
+	 *      },
+	 *  },
+	 *  parameters={
+	 *      {"name"="xp", "dataType"="integer", "required"=true, "description"="Number of XP earned to apply to the upgrade"},
+	 *      {"name"="exiles", "dataType"="string", "required"=false, "description"="Optional comma separated list of card codes to 'exile'. All passed codes must be present in the existing deck and must be exilable cards."},
+	 *  },
+	 * )
+	 * @param Request $request
+	 */
+	public function upgradeDeckAction($id, Request $request) {
+		/* @var $em \Doctrine\ORM\EntityManager */
+		$em = $this->getDoctrine()->getManager();
+
+		if(!$id) {
+			return new JsonResponse([
+				'success' => FALSE,
+				'msg' => 'id of deck is required.'
+			]);
+		}
+
+		/* @var $deck \AppBundle\Entity\Deck */
+		$deck = $em->getRepository('AppBundle:Deck')->find($id);
+		if (!$deck){
+			return false;
+		}
+		if ($deck->getNextDeck()) {
+			return new JsonResponse([
+				'success' => FALSE,
+				'msg' => 'Deck is locked.'
+			]);
+		}
+		$is_owner = $this->getUser() && $this->getUser()->getId() == $deck->getUser()->getId();
+		if(!$is_owner) {
+			return new JsonResponse([
+				'success' => FALSE,
+				'msg' => 'You are not allowed to upgrade this deck, you are not the owner.'
+			]);
+		}
+
+
+		$slots = [];
+		foreach ($deck->getSlots() as $slot) {
+			$slots[$slot->getCard()->getCode()] = $slot->getQuantity();
+		}
+
+		if ($request->get('exiles')){
+			$exiles = filter_var_array(explode(',', $request->get('exiles')), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+		} else {
+			$exiles = false;
+		}
+		$filtered_exiles = [];
+		$filtered_exile_cards = [];
+		$exile_counts=[];
+		if ($exiles) {
+			foreach ($exiles as $exile) {
+				$exile_card = $em->getRepository('AppBundle:Card')->findOneBy(array("code" => $exile));
+				// Validate that the exile card code is valid and is exilable.
+				if ($exile_card && $exile_card->getExile()) {
+					$filtered_exile_cards[] = $exile_card;
+					$filtered_exiles[] = $exile_card->getCode();
+
+					// Keep track of total count of each exile card.
+					if (!isset($exile_counts[$exile_card->getCode()])) {
+						$exile_counts[$exile_card->getCode()] = 0;
+					}
+					$exile_counts[$exile_card->getCode()] = $exile_counts[$exile_card->getCode()] + 1;
+
+					// Check if the deck contains enough cards to exile, so we don't 'over' exile.
+					$slot_count = isset($slots[$exile_card->getCode()]) ? $slots[$exile_card->getCode()] : 0;
+					if ($slot_count < $exile_counts[$exile_card->getCode()]) {
+						return new JsonResponse([
+							'success' => FALSE,
+							'msg' => 'Not enough count to exile: '.$exile
+						]);
+					}
+				} else {
+					return new JsonResponse([
+						'success' => FALSE,
+						'msg' => 'Invalid exile card: '.$exile
+					]);
+				}
+			}
+		}
+
+		// Read the XP for the upgrade.
+		$xp = filter_var($request->get('xp'), FILTER_SANITIZE_NUMBER_INT);
+
+		// Account for any carryover XP from the previous deck (old - spent).
+		if ($deck->getXp()){
+			$xp += $deck->getXp();
+		}
+		if ($deck->getXpSpent()){
+			$xp -= $deck->getXpSpent();
+		}
+
+		// No decklist_id parameter, used when cloning/copying decks.
+		$decklist_id = null;
+
+		// Create and save a new deck.
+		$newDeck = new Deck();
+		$this->get('decks')->saveDeck(
+			$this->getUser(),
+			$newDeck,
+			$decklist_id,
+			$deck->getName(),
+			$deck->getCharacter(),
+			$deck->getDescriptionMd(),
+			$deck->getTags(),
+			$slots,
+			null, // no source deck, we want it to be new.
+			$deck->getProblem()
+		);
+
+		if ($filtered_exiles) {
+			// Set exiled cards if there were any sent in the request.
+			$newDeck->setExiles(implode(",",$filtered_exiles));
+		}
+
+		// Upgrade action takes care of setting XP, removing exiles, and linking
+		// the deck to the previous incarnation (and managing upgrades).
+		$this->get('decks')->upgradeDeck(
+			$newDeck,
+			$xp,
+			$deck,
+			$deck->getUpgrades(),
+			$filtered_exile_cards
+		);
+
+		// Send changes back to the database.
+		$em->flush();
+
+		// Return the new deck id.
+		return new JsonResponse([
+			'success' => TRUE,
+			'msg' => $newDeck->getId(),
+		]);
+	}
+
 
 	/**
 	 * Save one Deck of the authenticated user. The parameters are the same as in the response to the load method, but only a few are writable.
@@ -104,16 +372,16 @@ class Oauth2Controller extends Controller
 	 *          "name"="id",
 	 *          "dataType"="integer",
 	 *          "requirement"="\d+",
-	 *          "description"="The numeric identifier of the Deck to load ; 0 to create a new Deck"
+	 *          "description"="The numeric identifier of the Deck to update.
 	 *      },
 	 *  },
 	 *  parameters={
-	 *      {"name"="name", "dataType"="string", "required"=true, "description"="Name of the Deck"},
+	 *      {"name"="name", "dataType"="string", "required"=false, "description"="Name of the Deck if a change is needed."},
 	 *      {"name"="decklist_id", "dataType"="integer", "required"=false, "description"="Identifier of the Decklist from which the Deck is copied"},
 	 *      {"name"="description_md", "dataType"="string", "required"=false, "description"="Description of the Decklist in Markdown"},
-	 *      {"name"="faction_code", "dataType"="string", "required"=false, "description"="Code of the faction of the Deck"},
 	 *      {"name"="tags", "dataType"="string", "required"=false, "description"="Space-separated list of tags"},
 	 *      {"name"="slots", "dataType"="string", "required"=true, "description"="Content of the Decklist as a JSON object"},
+	 *      {"name"="problem", "dataType"="string", "required"=true, "description"="A short code description of the problem with the provided slots, if one exists. Must be one of: too_few_cards,too_many_cards,too_many_copies,invalid_cards,deck_options_limit,investigator"}
 	 *  },
 	 * )
 	 * @param Request $request
@@ -121,36 +389,41 @@ class Oauth2Controller extends Controller
 	public function saveDeckAction($id, Request $request)
 	{
 		/* @var $deck \AppBundle\Entity\Deck */
+		$em = $this->getDoctrine()->getManager();
 
-		if(!$id)
-		{
-			$deck = new Deck();
-			$this->getDoctrine()->getManager()->persist($deck);
-		}
-		else
-		{
-			$deck = $this->getDoctrine()->getRepository('AppBundle:Deck')->find($id);
-			if($deck->getUser()->getId() !== $this->getUser()->getId())
-			{
-				throw $this->createAccessDeniedException("Access denied to this object.");
-			}
-		}
-		
-		$faction_code = filter_var($request->get('faction_code'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
-		if(!$faction_code) {
+		if(!$id) {
 			return new JsonResponse([
-					'success' => FALSE,
-					'msg' => "Faction code missing"
+				'success' => FALSE,
+				'msg' => 'id of deck is required.'
 			]);
 		}
-		$faction = $this->getDoctrine()->getManager()->getRepository('AppBundle:Faction')->findOneBy(['code' => $faction_code]);
-		if(!$faction) {
+
+		// A deck ID was provided, so we lookup the deck that is being modified.
+		$deck = $this->getDoctrine()->getRepository('AppBundle:Deck')->find($id);
+		if($deck->getUser()->getId() !== $this->getUser()->getId()) {
 			return new JsonResponse([
-					'success' => FALSE,
-					'msg' => "Faction code invalid"
+				'success' => FALSE,
+				'msg' => 'You are not allowed to edit this deck, you are not the owner.'
 			]);
 		}
-		
+		if ($deck->getNextDeck()) {
+			return new JsonResponse([
+				'success' => FALSE,
+				'msg' => 'Deck is locked.'
+			]);
+		}
+
+		// Don't allow investigator to be changed when 'editing' a deck.
+		// Seems unnecessary and is bound to break something.
+		$investigator = $deck->getCharacter();
+		if (!$investigator) {
+			return new JsonResponse([
+				'success' => FALSE,
+				'msg' => "Investigator code invalid"
+			]);
+		}
+
+		// Slots is the one required parameter.
 		$slots = (array) json_decode($request->get('slots'));
 		if (!count($slots)) {
 			return new JsonResponse([
@@ -158,33 +431,71 @@ class Oauth2Controller extends Controller
 					'msg' => "Slots missing"
 			]);
 		}
-		foreach($slots as $card_code => $qty)
-		{
-			if(!is_string($card_code) || !is_integer($qty))
-			{
+
+		foreach($slots as $card_code => $qty) {
+			if(!is_string($card_code) || !is_integer($qty)) {
 				return new JsonResponse([
 						'success' => FALSE,
 						'msg' => "Slots invalid"
 				]);
 			}
 		}
-		
-		$name = filter_var($request->get('name'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
-		if(!$name) {
+		// We expect all requests to include problem.
+		$problem = filter_var($request->get('problem'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+		if (!empty($problem) && !in_array($problem, [
+			'too_few_cards',
+			'too_many_cards',
+			'too_many_copies',
+			'invalid_cards',
+			'deck_options_limit',
+			'investigator'], true)) {
 			return new JsonResponse([
 					'success' => FALSE,
-					'msg' => "Name missing"
+					'msg' => "Invalid problem"
 			]);
 		}
-		
+		$name = filter_var($request->get('name'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+		if(!$name) {
+			if ($deck->getName()) {
+				$name = $deck->getName();
+			} else {
+				return new JsonResponse([
+						'success' => FALSE,
+						'msg' => "Name missing"
+				]);
+			}
+		}
+
 		$decklist_id = filter_var($request->get('decklist_id'), FILTER_SANITIZE_NUMBER_INT);
+		if (!$decklist_id && $deck->getParent()) {
+			// Don't override the parent if this deck was copied and a param was not specified.
+			$decklist_id = $deck->getParent();
+		}
+
 		$description = trim($request->get('description'));
+		if (!$description && $deck->getDescriptionMd()) {
+			// Leave description alone if it was not specified (or was blank?).
+			$description = $deck->getDescriptionMd();
+		}
+
 		$tags = filter_var($request->get('tags'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
-		
-		$this->get('decks')->saveDeck($this->getUser(), $deck, $decklist_id, $name, $faction, $description, $tags, $slots, null);
-		
-		$this->getDoctrine()->getManager()->flush();
-		
+		if (!$tags && $deck->getTags()) {
+			// Leave tags alone if they were blank.
+			$tags = $deck->getTags();
+		}
+
+		// Save the deck.
+		$this->get('decks')->saveDeck($this->getUser(), $deck, $decklist_id, $name, $investigator, $description, $tags, $slots, $deck , $problem);
+
+		// xp_spent is only read/set if there was a previousDeck.
+		if ($deck->getPreviousDeck() && $request->get('xp_spent') !== null) {
+			$xp_spent = filter_var($request->get('xp_spent'), FILTER_SANITIZE_NUMBER_INT);
+			$deck->setXpSpent($xp_spent);
+		}
+
+		// Actually flush the database edits.
+		$em->flush();
+
 		return new JsonResponse([
 				'success' => TRUE,
 				'msg' => $deck->getId()
@@ -193,7 +504,7 @@ class Oauth2Controller extends Controller
 
 	/**
 	 * Try to publish one Deck of the authenticated user
-	 * If publication is successful, update the version of the deck and return the id of the decklist 
+	 * If publication is successful, update the version of the deck and return the id of the decklist
 	 *
 	 * @ApiDoc(
 	 *  section="Deck",
@@ -222,18 +533,18 @@ class Oauth2Controller extends Controller
 		if ($this->getUser()->getId() !== $deck->getUser()->getId()) {
 			throw $this->createAccessDeniedException("Access denied to this object.");
 		}
-		
+
 		$name = filter_var($request->request->get('name'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
 		$descriptionMd = trim($request->request->get('description_md'));
-		
+
 		$tournament_id = intval(filter_var($request->request->get('tournament_id'), FILTER_SANITIZE_NUMBER_INT));
 		$tournament = $this->getDoctrine()->getManager()->getRepository('AppBundle:Tournament')->find($tournament_id);
 
 		$precedent_id = trim($request->request->get('precedent'));
-		if(!preg_match('/^\d+$/', $precedent_id)) 
+		if(!preg_match('/^\d+$/', $precedent_id))
 		{
 			// route decklist_detail hard-coded
-			if(preg_match('/view\/(\d+)/', $precedent_id, $matches)) 
+			if(preg_match('/view\/(\d+)/', $precedent_id, $matches))
 			{
 				$precedent_id = $matches[1];
 			}
@@ -243,8 +554,8 @@ class Oauth2Controller extends Controller
 			}
 		}
 		$precedent = $precedent_id ? $em->getRepository('AppBundle:Decklist')->find($precedent_id) : null;
-		
-        try 
+
+        try
         {
         	$decklist = $this->get('decklist_factory')->createDecklistFromDeck($deck, $name, $descriptionMd);
         }
@@ -255,7 +566,7 @@ class Oauth2Controller extends Controller
         			'msg' => $e->getMessage()
         	]);
         }
-        
+
         $decklist->setTournament($tournament);
         $decklist->setPrecedent($precedent);
         $this->getDoctrine()->getManager()->persist($decklist);

--- a/src/AppBundle/Resources/config/routing/api/routing_api_oauth2.yml
+++ b/src/AppBundle/Resources/config/routing/api/routing_api_oauth2.yml
@@ -13,11 +13,27 @@ api_oauth2_load_deck:
     requirements:
         id: \d+
 
+api_oauth2_new_deck:
+    path: /deck/new
+    methods: [POST]
+    defaults:
+        _controller: AppBundle:Oauth2:newDeck
+    requirements:
+        id: \d+
+
 api_oauth2_save_deck:
     path: /deck/save/{id}
     methods: [PUT]
     defaults:
         _controller: AppBundle:Oauth2:saveDeck
+    requirements:
+        id: \d+
+
+api_oauth2_upgrade_deck:
+    path: /deck/upgrade/{id}
+    methods: [PUT]
+    defaults:
+        _controller: AppBundle:Oauth2:upgradeDeck
     requirements:
         id: \d+
 


### PR DESCRIPTION
It seems like the OAuth2 bundle was mostly still tied to the ThronesDB code.  I had some free time today, so I went ahead and ported over the rest of the functionality, and split them up into separate functions to be a bit more maintainable.  I think it's pretty safe to make the breaking API change in this situation.

The new endpoints are as follows
1) /oauth2/deck/save/:id  -- Save endpoint for editing existing decks.  The old save endpoint was trying to do both new decks and deck edits, but we don't really want to support changing investigator so it seemed safer to split them completely.
2) /oauth2/deck/new -- New deck endpoint, to create an empty deck given an investigator
id/name
3) /oauth2/deck/upgrade/:id Upgrade deck endpoint, to handle XP + Exile and proper deck linking

I also made a small fix to the 'load' endpoint to allow 'shared' decks to be read.

I've validated as much of the input data for the endpoints as possible to avoid common misuse cases, (exile cards for example).  I've also tried to validate strings that are actually enums (problem).

Happy to make any/all changes needed to help get this landed. I'm still somewhat new to PHP, but I've just tried to test the endpoints out as much as possible to isolate the problems, and I think its about ready.