### PR TITLE
Change bold/italic parse to work with translations

### DIFF
--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -151,7 +151,7 @@ format.info = function info(card) {
  */
 format.text = function text(card) {
 	var text = card.text || '';
-	text = text.replace(/\[\[([\w-]+)\]\]/g, '<b><i>$1</i></b>');
+	text = text.replace(/\[\[([^\]]+)\]\]/g, '<b><i>$1</i></b>');
 	text = text.replace(/\[(\w+)\]/g, '<span title="$1" class="icon-$1"></span>');
 	text = text.split("\n").join('</p><p>');
 	return '<p>'+text+'</p>';
@@ -162,7 +162,7 @@ format.text = function text(card) {
  */
 format.back_text = function back_text(card) {
 	var text = card.back_text || '';
-	text = text.replace(/\[\[([\w-]+)\]\]/g, '<b><i>$1</i></b>');
+	text = text.replace(/\[\[([^\]]+)\]\]/g, '<b><i>$1</i></b>');
 	text = text.replace(/\[(\w+)\]/g, '<span title="$1" class="icon-$1"></span>')
 	text = text.split("\n").join('</p><p>');
 	return '<p>'+text+'</p>';
@@ -173,7 +173,7 @@ format.back_text = function back_text(card) {
  */
 format.html_page = function back_text(element) {
 	var curInnerHTML = element.innerHTML;
-	curInnerHTML = curInnerHTML.replace(/\[\[([\w-]+)\]\]/g, '<b><i>$1</i></b>');
+	curInnerHTML = curInnerHTML.replace(/\[\[([^\]]+)\]\]/g, '<b><i>$1</i></b>');
 	curInnerHTML = curInnerHTML.replace(/\[(\w+)\]/g, '<span title="$1" class="icon-$1"></span>');
 	element.innerHTML = curInnerHTML;
 };

--- a/src/AppBundle/Services/CardsData.php
+++ b/src/AppBundle/Services/CardsData.php
@@ -58,7 +58,7 @@ class CardsData
 			'[neutral]' => '<span class="icon-neutral" title="Neutral">Neutral</span>',
 			'[per_investigator]' => '<span class="icon-per_investigator" title="Per Investigator"></span>'
 		];
-		$text = preg_replace("/\[\[(\w+)\]\]/", '<b><i>${1}</i></b>', $text);
+		$text = preg_replace("/\[\[([^\]]+)\]\]/", '<b><i>${1}</i></b>', $text);
 		return str_replace(array_keys($displayTextReplacements), array_values($displayTextReplacements), $text);
 	}
 	


### PR DESCRIPTION
Traits seem to be multi-word in some languages, this will let us parse
them as a single trait still.

Use a negated `]` as the match instead of `\w`