### PR TITLE
Add a 'change account' button to the auth view.

### DIFF
--- a/app/Resources/FOSOAuthServerBundle/views/Authorize/authorize_content.html.twig
+++ b/app/Resources/FOSOAuthServerBundle/views/Authorize/authorize_content.html.twig
@@ -5,7 +5,7 @@
 </div>
 <div class="panel-body">
 	  <p>
-		  The application <i>{{ client.name }}</i> would like to connect to your account.
+		  The application <i>{{ client.name }}</i> would like to connect to your account. Click <a href="/login">here</a> to change accounts.
 	  </p>
 	  <p>
 		   If you agree, <i>{{ client.name }}</i> will be able to perform the following operations on your behalf:


### PR DESCRIPTION
Had some people trying to change accounts, which wasn't possible on iOS because of the weird way webview work on the platform.