### PR TITLE
Increase the memory limit on import statement

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -41,7 +41,8 @@ class ImportStdCommand extends ContainerAwareCommand
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output)
-	{
+  {
+    ini_set('memory_limit', '2G');
 		$path = $input->getArgument('path');
 		$this->em = $this->getContainer()->get('doctrine')->getEntityManager();
 		$this->output = $output;


### PR DESCRIPTION
When importing the full set of cards, it runs out of memory with default limits.