### PR TITLE
Fix deck save with meta

### DIFF
--- a/src/AppBundle/Controller/Oauth2Controller.php
+++ b/src/AppBundle/Controller/Oauth2Controller.php
@@ -585,7 +585,7 @@ class Oauth2Controller extends Controller
 		// Save the deck.
 		$this->get('decks')->saveDeck($this->getUser(), $deck, $decklist_id, $name, $investigator, $description, $tags, $slots, $deck , $problem, $ignored);
 		if ($meta_json) {
-			$deck->setMeta($meta_json);
+			$deck->setMeta($meta);
 		}
 		$deck->setTaboo($taboo);
 


### PR DESCRIPTION
Typo on what was being passed to setMeta, should have been `meta` (string) not `meta_json` (object)