### PR TITLE
Add bin/console exception for .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 /app/logs/*
 !app/logs/.gitkeep
 /app/phpunit.xml
-/bin/
+/bin/*
+!bin/console
 /composer.phar
 /vendor/
 /web/bundles/


### PR DESCRIPTION
This should allow your copy of /bin/console to be committed to the repo, after merging you can run `git add bin` and it will add just the necessary `bin/console` but not anything else.