### PR TITLE
Fix issue with save deck in the API

### DIFF
--- a/src/AppBundle/Controller/Oauth2Controller.php
+++ b/src/AppBundle/Controller/Oauth2Controller.php
@@ -574,7 +574,8 @@ class Oauth2Controller extends Controller
 		}
 
 		foreach($slots as $card_code => $qty) {
-			if(!is_string($card_code) || !is_integer($qty)) {
+			// type-juggling means codes that don't start with 0 become integers.
+			if((!is_string($card_code) && !is_integer($card_code)) || !is_integer($qty)) {
 				return new JsonResponse([
 						'success' => FALSE,
 						'msg' => "Slots invalid"
@@ -588,7 +589,8 @@ class Oauth2Controller extends Controller
 			if (count($ignored_array)) {
 				$ignored = $ignored_array;
 				foreach($ignored as $card_code => $qty) {
-					if(!is_string($card_code) || !is_integer($qty)) {
+					// type-juggling means codes that don't start with 0 become integers.
+					if((!is_string($card_code) && !is_integer($card_code)) || !is_integer($qty)) {
 						return new JsonResponse([
 								'success' => FALSE,
 								'msg' => "Ignored slots invalid"


### PR DESCRIPTION
Seems like the new version of PHP changed how JSON strings get decoded?
Cards from late cycles (return/standalone) that don't start with a
leading 0 are being decoded as 'ints' instead of 'strings' (despite
being a String in the passed in JSON).

The claim on the internet is that this will fix it: https://stackoverflow.com/questions/28109419/json-decode-decodes-large-numeric-string-as-integer