### PR TITLE
Fix missing search type for enemy fight

### DIFF
--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -77,7 +77,7 @@ class SearchController extends Controller
 			'sh' => 'integer',
 			'ed' => 'integer',
 			'eh' => 'integer',
-			'ee' => 'integer',
+			'ef' => 'integer',
 			'ee' => 'integer',
 			'do' => 'special'
 	);


### PR DESCRIPTION
The typo here prevented successful searches using the enemy fight score