### PR TITLE
preselect xp input field when upgrading

### DIFF
--- a/src/AppBundle/Resources/public/js/ui.deckview.js
+++ b/src/AppBundle/Resources/public/js/ui.deckview.js
@@ -38,7 +38,7 @@ ui.upgrade = function upgrade(deck_id) {
 	}
 	$('#upgrade_xp').val(0);
 	$('#upgradeModal').modal('show');
-	setTimeout(function() { $('#upgrade_xp').focus(); }, 500);
+	setTimeout(function() { $('#upgrade_xp').focus().select(); }, 500);
 }
 
 ui.create_exile_list = function create_exile_list(){


### PR DESCRIPTION
After clicking the upgrade button of a deck, the focus is in the input field. For convenience purpose I made it preselected.