### PR TITLE
Multilanguage random basic weakness selection

### DIFF
--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -762,7 +762,7 @@ deck.create_card = function create_card(card){
 		}
 	}
 	
-	if (card.name == "Random Basic Weakness" && $("#special-collection").length > 0 ){
+	if (card.code == "01000" && $("#special-collection").length > 0 ){
 		$div.append(' <a class="fa fa-random" title="Replace with randomly selected weakness from currently selected packs" data-random="'+card.code+'"> <span ></span></a> ');
 	}
 	return $div;

--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -797,7 +797,7 @@ ui.select_basic_weakness = function select_basic_weakness() {
 	weaknesses.forEach(function (card){
 		//console.log(card);
 		
-		if($("[name="+card.pack_code+"]").is(":checked") && card.name != "Random Basic Weakness" && card.indeck < card.maxqty){
+		if($("[name="+card.pack_code+"]").is(":checked") && card.code != "01000" && card.indeck < card.maxqty){
 			filtered_weaknesses.push(card);
 		}
 	});


### PR DESCRIPTION
As pointed on [this issue](https://github.com/Kamalisk/arkhamdb/issues/303), random basic weakness replace button wasn't being shown in languages other than english due to it was filtered by (english) name.

This change filters by code so it can be shown and be used in every language.

![Captura de pantalla 2020-08-10 a las 1 39 40](https://user-images.githubusercontent.com/1595352/89744192-e46f0d00-daaa-11ea-9578-2fff2823262a.png)
