### PR TITLE
Mark slot as translateable

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -500,6 +500,9 @@ class ImportStdCommand extends ContainerAwareCommand
 				if ($card->getText()){
 					$card->setRealText($card->getText());
 				}
+                                if ($card->getSlot()){
+                                        $card->setRealSlot($card->getSlot());
+                                }
 				$result[] = $card;
 				$this->em->persist($card);
 				if (isset($cardData['back_link'])){

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -2175,4 +2175,33 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	{
 		return $this->bondedCount;
 	}
+    /**
+     * @var string
+     */
+    private $realSlot;
+
+
+    /**
+     * Set realSlot.
+     *
+     * @param string $realSlot
+     *
+     * @return Card
+     */
+    public function setRealSlot($realSlot)
+    {
+        $this->realSlot = $realSlot;
+
+        return $this;
+    }
+
+    /**
+     * Get realSlot.
+     *
+     * @return string
+     */
+    public function getRealSlot()
+    {
+        return $this->realSlot;
+    }
 }

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -209,6 +209,12 @@ AppBundle\Entity\Card:
             type: string
             length: 50
             nullable: true
+            gedmo:
+                - translatable
+        realSlot:
+            type: string
+            length: 50
+            nullable: false
         stage:
             type: smallint
             nullable: true

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -697,8 +697,8 @@ deck.get_layout_data_one_section = function get_layout_data_one_section(query, d
 				var $div = deck.create_card(card);
 
 
-				if (card.slot && slots[card.slot]){
-					slots[card.slot].push($div);
+				if (card.real_slot && slots[card.real_slot]){
+					slots[card.real_slot].push($div);
 				} else {
 					slots["Other"].push($div);
 				}
@@ -1112,7 +1112,7 @@ deck.can_include_card = function can_include_card(card, limit_count, hard_count)
 				for(var j = 0; j < option.slot.length; j++){
 					var slot = option.slot[j];
 					
-					if (card.slot && card.slot.toUpperCase().indexOf(slot.toUpperCase()) !== -1){
+					if (card.real_slot && card.real_slot.toUpperCase().indexOf(slot.toUpperCase()) !== -1){
 						slot_valid = true;
 					}
 				}


### PR DESCRIPTION
Need a real_slot for this one so that it works with deck building (new OYO uses slot).

Didn't update charts since the localized name should be fine there, but can update if you we should?
- Advantage of not updating it, it gets localized for free
- Disadvantage, if cards are not fully translated it will show up as two different names?