### PR TITLE
Add real_back_text for translation.

### DIFF
--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -2204,4 +2204,33 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
     {
         return $this->realSlot;
     }
+    /**
+     * @var string|null
+     */
+    private $realBackText;
+
+
+    /**
+     * Set realBackText.
+     *
+     * @param string|null $realBackText
+     *
+     * @return Card
+     */
+    public function setRealBackText($realBackText = null)
+    {
+        $this->realBackText = $realBackText;
+
+        return $this;
+    }
+
+    /**
+     * Get realBackText.
+     *
+     * @return string|null
+     */
+    public function getRealBackText()
+    {
+        return $this->realBackText;
+    }
 }

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -82,7 +82,7 @@ AppBundle\Entity\Card:
                 default: false
         myriad:
             type: boolean
-            column: myriad            
+            column: myriad
             nullable: true
         encounterPosition:
             type: smallint
@@ -275,6 +275,9 @@ AppBundle\Entity\Card:
             nullable: true
             gedmo:
                 - translatable
+        realBackText:
+            type: text
+            nullable: true
         backFlavor:
             type: text
             nullable: true


### PR DESCRIPTION
Useful for things like scenario cards, where the back text contains information that would be nice to parse in english.

I'll update the import script once the refactor lands (https://github.com/Kamalisk/arkhamdb/pull/326)