### PR TITLE
Add card level to search results popup

### DIFF
--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -1152,15 +1152,30 @@ ui.setup_typeahead = function setup_typeahead() {
 		cb(app.data.cards.find({name: regexp}));
 	}
 
-	$('#filter-text').typeahead({
-		hint: true,
-		highlight: true,
-		minLength: 2
-	},{
-		name : 'cardnames',
-		displayKey: 'name',
-		source: findMatches
-	});
+  $('#filter-text').typeahead({
+    hint: true,
+    highlight: true,
+    minLength: 2
+  },{
+    name : 'cardnames',
+    display: function(data) {
+      var value = data.name;
+      if (data.xp && data.xp > 0) {
+        value = data.name + ' (' + data.xp + ')';
+      }
+      return value;
+    },
+    source: findMatches,
+    templates: {
+      suggestion: function (data){
+        var value = data.name;
+        if (data.xp && data.xp > 0) {
+          value = data.name+' ('+data.xp+')';
+        }
+        return '<div>' + value + '</div>';
+      }
+    }
+  });
 
 }
 


### PR DESCRIPTION
When you're typing to filter the card list, if there are multiple cards of the same name with differing XP values, you have no idea which one is which. Added level indication (e.g. 'Deduction (2)' for the level 2 version).
