### PR TITLE
Fixing exception in deck editor screen

### DIFF
--- a/src/AppBundle/Resources/public/js/app.deck_history.js
+++ b/src/AppBundle/Resources/public/js/app.deck_history.js
@@ -124,7 +124,7 @@ deck_history.all_changes = function all_changes() {
 				addition_xp += addition.card.taboo_xp;
 			}
 			if (removal.card.taboo_xp){
-				removal_xp += removal_xp.card.taboo_xp;
+				removal_xp += removal.card.taboo_xp;
 			}
 			if (addition.qty > 0 && removal.qty > 0 && addition_xp >= 0 && addition.card.real_name == removal.card.real_name && addition_xp > removal_xp){
 				addition.qty = addition.qty - removal.qty;

--- a/src/AppBundle/Resources/public/js/app.deck_upgrades.js
+++ b/src/AppBundle/Resources/public/js/app.deck_upgrades.js
@@ -109,7 +109,7 @@ deck_upgrades.display = function display() {
 					addition_xp += addition.card.taboo_xp;
 				}
 				if (removal.card.taboo_xp){
-					removal_xp += removal_xp.card.taboo_xp;
+					removal_xp += removal.card.taboo_xp;
 				}
 				if (addition.qty > 0 && removal.qty > 0 && addition_xp >= 0 && addition.card.real_name == removal.card.real_name && addition_xp > removal_xp){
 					addition.qty = addition.qty - removal.qty;


### PR DESCRIPTION
This is a change to fix an issue I've been experiencing with the deck editor, where this deck: https://arkhamdb.com/deck/view/1033567 results in an uncaught JS exception that breaks a lot of functionality, like the charts and the draw simulator. The issue seems to be a typo where removal_xp is accessed rather than the removal object, which is the one that contains the existence check.

To be honest I haven't actually tested this by building a local ArkhamDB instance and seeing what happens; I've intercepted the app.js request on the actual arkham website with Fiddle and served up an app.js containing my change, and everything seems to work all right, but I don't know enough about ArkhamDB's code base to know whether this will have knock-on effects. Regardless, it seems like a simple enough change that I think it's unlikely anything will break, so I feel pretty OK about making this pull request.