### PR TITLE
Change OG card type

### DIFF
--- a/src/AppBundle/Resources/views/layout.html.twig
+++ b/src/AppBundle/Resources/views/layout.html.twig
@@ -16,8 +16,11 @@
     {% set currentPath = path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) %}
     {% if "/card" in currentPath and cards is defined and cards[0] is defined %}
       {% if cards[0].name is defined %}<meta property="og:title" content="{{ cards[0].name }} &middot; ArkhamDB" />{% endif %}
-      {% if cards[0].real_text is defined %}<meta property="og:description" content="{{ cards[0].real_text }}" />{% endif %}
-      {% if cards[0].imagesrc is defined and cards[0].imagesrc %}<meta property="og:image" content="{{ app.request.scheme ~'://' ~ app.request.httpHost ~ asset(cards[0].imagesrc) }}" />{% endif %}
+      {% if cards[0].real_text is defined %}<meta property="og:description" content="{{ cards[0].real_text|striptags }}" />{% endif %}
+      {% if cards[0].imagesrc is defined and cards[0].imagesrc %}
+          <meta property="og:image" content="{{ app.request.scheme ~'://' ~ app.request.httpHost ~ asset(cards[0].imagesrc) }}" />
+          <meta name="twitter:card" content="summary_large_image">
+      {% endif %}
     {% endif %}
 
     <link href='https://fonts.googleapis.com/css?family=Amiri:400,400italic,700,700italic|Julius+Sans+One|Open+Sans:400,400italic,700,700italic|Open+Sans+Condensed:300' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Sorry for reopening it, I didn't know about a possibility to test og tags locally and also didn't know that Telegram needs <meta name="twitter:card" content="summary_large_image"> to display big images.

This is how it looks right now in Telegram
![image](https://user-images.githubusercontent.com/3006537/106614554-8c5a2480-657c-11eb-9b3d-c5712263952a.png)

This is how it will look like with summary_large_image tag
![image](https://user-images.githubusercontent.com/3006537/106614605-9a0faa00-657c-11eb-948d-8669aef94a58.png)