### PR TITLE
Add cycles to API

### DIFF
--- a/src/AppBundle/Resources/config/routing/api/routing_api_public.yml
+++ b/src/AppBundle/Resources/config/routing/api/routing_api_public.yml
@@ -4,6 +4,12 @@ api_packs:
     defaults:
         _controller: AppBundle:Api:listPacks
 
+api_cycles:
+    path: /cycles/
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Api:listCycles
+
 api_factions:
     path: /factions/
     methods: [GET]

--- a/src/AppBundle/Tests/Controller/ApiControllerTest.php
+++ b/src/AppBundle/Tests/Controller/ApiControllerTest.php
@@ -65,6 +65,19 @@ class ApiControllerTest extends WebTestCase
     	$this->assertInternalType('array', $data);
     	$this->assertNotEmpty($data);
     }
+    
+    public function testListCycles()
+    {
+    	$client = static::createClient();
+       	$client->request('GET', '/api/cycles/');
+    	$response = $client->getResponse();
+    	$json = $response->getContent();
+    	$this->assertJson($json);
+    	$data = json_decode($json, true);
+    	$this->assertNotNull($data);
+    	$this->assertInternalType('array', $data);
+    	$this->assertNotEmpty($data);
+    }
 
    	public function testGetDecklist()
    	{


### PR DESCRIPTION
So bad etiquette I know but I've not tested this because I don't want to install everything.

This just exposes the cycle api and adds additional the cycle data to the packs api.