### PR TITLE
In Card view, center "Deck Quantity" like it used to be

### DIFF
--- a/src/AppBundle/Resources/views/Modale/card.html.twig
+++ b/src/AppBundle/Resources/views/Modale/card.html.twig
@@ -6,14 +6,14 @@
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                 <h3 class="modal-title card-name">Modal title</h3>
                 <div class="row modal-deck-options">
+                    <div class="col-sm-4 text-center modal-side-deck-qty">
+                        Side Deck Quantity: <div class="btn-group modal-side-qty" data-toggle="buttons"></div>
+                    </div>
                     <div class="col-sm-4 text-center modal-deck-qty">
                         Deck Quantity: <div class="btn-group modal-qty" data-toggle="buttons"></div>
                     </div>
                     <div class="col-sm-4 text-center modal-deck-ignore">
                         Ignore Limit: <div class="btn-group modal-ignore" data-toggle="buttons"></div>
-                    </div>
-                    <div class="col-sm-4 text-center modal-side-deck-qty">
-                        Side Deck Quantity: <div class="btn-group modal-side-qty" data-toggle="buttons"></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Since the addition of Side Deck Quantity and Ignore Limit, the Deck Quantity buttons are no longer centered in the modal.
I think a lot of people mistakenly click the quantity in the center (out of habit).
Moreover if there is an ignore limit, side deck is again pushed to the right.
![image](https://user-images.githubusercontent.com/2650589/114745863-648ef600-9d4f-11eb-8350-31ceda09a037.png)


It might be better to have the main concern "Deck Quantity" centered like it used to be.
![image](https://user-images.githubusercontent.com/2650589/114745881-6953aa00-9d4f-11eb-8cb4-9e9a2f5a6faa.png)