### PR TITLE
Create filter by dateCreation before/after

### DIFF
--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -360,6 +360,8 @@ class SocialController extends Controller
 		$decklist_name = filter_var($request->query->get('name'), FILTER_SANITIZE_STRING);
 		$sort = $request->query->get('sort');
 		$packs = $request->query->get('packs');
+		$date_from = $request->query->get('date_from');
+		$date_to = $request->query->get('date_to');
 
 		if(!is_array($packs)) {
 			$packs = $dbh->executeQuery("select id from pack")->fetchAll(\PDO::FETCH_COLUMN);
@@ -398,7 +400,9 @@ class SocialController extends Controller
 		'on' => $on,
 		'off' => $off,
 		'author' => $author_name,
-		'name' => $decklist_name
+		'name' => $decklist_name,
+		'date_from' => $date_from,
+		'date_to' => $date_to
 		);
 		$params['sort_'.$sort] = ' selected="selected"';
 		$params['factions'] = $dbh->executeQuery(

--- a/src/AppBundle/Model/DecklistManager.php
+++ b/src/AppBundle/Model/DecklistManager.php
@@ -203,6 +203,10 @@ class DecklistManager
 
 		$decklist_name = filter_var($request->query->get('name'), FILTER_SANITIZE_STRING);
 
+		$date_from = $request->query->get('date_from');
+
+		$date_to = $request->query->get('date_to');
+
 		$sort = $request->query->get('sort');
 
 		$packs = $request->query->get('packs');
@@ -225,6 +229,14 @@ class DecklistManager
 		if(! empty($decklist_name)) {
 			$qb->andWhere('d.name like :deckname');
 			$qb->setParameter('deckname', "%$decklist_name%");
+		}
+		if(! empty($date_from)) {
+			$qb->andWhere('d.dateCreation >= :date_from');
+			$qb->setParameter('date_from', "$date_from 00:00:00");
+		}
+		if(! empty($date_to)) {
+            $qb->andWhere('d.dateCreation <= :date_to');
+            $qb->setParameter('date_to', "$date_to 23:59:59");
 		}
 		if(!empty($cards_code) || !empty($packs)) {
 			if (!empty($cards_code) ) {

--- a/src/AppBundle/Resources/views/Search/form.html.twig
+++ b/src/AppBundle/Resources/views/Search/form.html.twig
@@ -28,6 +28,16 @@
 					placeholder="Enter text to search in name">
 			</div>
 			<div class="form-group">
+				<label for="">Decklist created after</label> <input type="date"
+				    class="form-control" id="date_from" name="date_from" value="{{ date_from }}"
+				    placeholder="Enter text to search in name">
+			</div>
+			<div class="form-group">
+				<label for="">Decklist created before</label> <input type="date"
+				    class="form-control" id="date_to" name="date_to" value="{{ date_to }}"
+				    placeholder="Enter text to search in name">
+			</div>
+			<div class="form-group">
 				<label for="">Sort</label> <select class="form-control" id="sort"
 					name="sort">
 					<option value="popularity"{{ sort_popularity|default('') }}>by Popularity</option>


### PR DESCRIPTION
I've created a filter that allows to filter decklists by creation date (created before some date, created after some date, or both).

**Justification** 
In Russia we are 2 years behind official release schedule. Right now, when I'm writing this, we're waiting for the release of In the Clutches of Chaos mythos pack. Sometimes I want to see, what decklists were posted & discussed by the community at the moment of the release of a certain pack/cycle AND also want to sort them by the number of likes or reputation of author, to see what META was at the moment or what did people create with the cards of certain pack.

I'm aware of "Select allowed packs" feature, but it doesn't quite work as I wish for, because if I choose everything up to In the Clutches of Chaos and sort by the number of likes, I will get all decklists from the beginning of the Arkham.db.

So I came up with this simple solution which allows me to get only decklists for example from the July of 2019 AND sort them by the reputation or the number of likes.

I used simple html datepickers, no additional installations, just plain & simple code.