### PR TITLE
Added path '/api/public/find?q=<query>' to find cads via API with the same query syntax used in cards listing

### DIFF
--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -510,6 +510,71 @@ class ApiController extends Controller
 		return $response;
 	}
 
+	/**
+	 * Find card(s) matching the same query format used on cards page on the web, as an array of JSON objects.
+	 *
+	 * @ApiDoc(
+	 *  section="Card",
+	 *  resource=true,
+	 *  description="All cards matching query",
+	 *  parameters={
+	 *      {"name"="q", "dataType"="string", "required"=false, "description"="The query to find cards"},
+	 *      {"name"="jsonp", "dataType"="string", "required"=false, "description"="JSONP callback"}
+	 *  }
+	 * )
+	 * @param Request $request
+	 */
+	public function findCardsAction(Request $request)
+	{
+		$locale = $request->getLocale();
+
+		$response = new Response();
+		$response->setPublic();
+		$response->setMaxAge($this->container->getParameter('cache_expiration'));
+		$response->headers->add(array(
+			'Access-Control-Allow-Origin' => '*',
+			'Content-Language' => $locale
+		));
+
+		$jsonp = $request->query->get('jsonp');
+		$q = $request->query->get('q');
+
+		$conditions = $this->get('cards_data')->syntax($q);
+		$this->get('cards_data')->validateConditions($conditions);
+		$query = $this->get('cards_data')->buildQueryFromConditions($conditions);
+
+		$cards = array();
+		$last_modified = null;
+		if($query && $rows = $this->get('cards_data')->get_search_rows($conditions, "set"))
+		{
+			for($rowindex = 0; $rowindex < count($rows); $rowindex++) {
+				if(empty($last_modified) || $last_modified < $rows[$rowindex]->getDateUpdate()) $last_modified = $rows[$rowindex]->getDateUpdate();
+			}
+			$response->setLastModified($last_modified);
+			if ($response->isNotModified($request)) {
+				return $response;
+			}
+			for($rowindex = 0; $rowindex < count($rows); $rowindex++) {
+				$card = $this->get('cards_data')->getCardInfo($rows[$rowindex], true, $locale);
+				$cards[] = $card;
+			}
+		}
+
+		// build the response
+
+		$content = json_encode($cards);
+		if(isset($jsonp))
+		{
+			$content = "$jsonp($content)";
+			$response->headers->set('Content-Type', 'application/javascript');
+		} else
+		{
+			$response->headers->set('Content-Type', 'application/json');
+		}
+		$response->setContent($content);
+		return $response;
+	}
+
 
 	/**
 	 * Get the description of a decklist as a JSON object.

--- a/src/AppBundle/Resources/config/routing/api/routing_api_public.yml
+++ b/src/AppBundle/Resources/config/routing/api/routing_api_public.yml
@@ -49,6 +49,12 @@ api_cards_pack:
     requirements:
         _format: json|xml|xlsx|xls
 
+api_cards_find:
+    path: /find
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Api:findCards
+
 api_decklist:
     path: /decklist/{decklist_id}.{_format}
     methods: [GET]


### PR DESCRIPTION
As I did in SWDestinyDB, this addition will be very helpful for 3rd party API consumers.