### PR TITLE
Fix modal with no traits

### DIFF
--- a/src/AppBundle/Resources/public/js/app.card_modal.js
+++ b/src/AppBundle/Resources/public/js/app.card_modal.js
@@ -58,7 +58,7 @@ function fill_modal (code) {
 	}
 
 	var qtyelt = modal.find('.modal-ignore');
-	if(qtyelt && card.maxqty && (card.code == "05040" || (card.real_traits && (card.real_traits.indexOf('Spell.') !== -1 || card.real_traits.indexOf('Fortune.') !== -1 || card.real_traits.indexOf('Gambit.') !== -1 )) ) {
+	if(qtyelt && card.maxqty && (card.code == "05040" || (card.real_traits && (card.real_traits.indexOf('Spell.') !== -1 || card.real_traits.indexOf('Fortune.') !== -1 || card.real_traits.indexOf('Gambit.') !== -1 )))) {
 		qtyelt.closest('.modal-deck-ignore').show();
 		var qty = '';
 		for(var i=0; i<=card.maxqty; i++) {

--- a/src/AppBundle/Resources/public/js/app.card_modal.js
+++ b/src/AppBundle/Resources/public/js/app.card_modal.js
@@ -58,7 +58,7 @@ function fill_modal (code) {
 	}
 
 	var qtyelt = modal.find('.modal-ignore');
-	if(qtyelt && card.maxqty && (card.code == "05040" || card.real_traits.indexOf('Spell.') !== -1 || card.real_traits.indexOf('Fortune.') !== -1 || card.real_traits.indexOf('Gambit.') !== -1 ) ) {
+	if(qtyelt && card.maxqty && (card.code == "05040" || (card.real_traits && (card.real_traits.indexOf('Spell.') !== -1 || card.real_traits.indexOf('Fortune.') !== -1 || card.real_traits.indexOf('Gambit.') !== -1 )) ) {
 		qtyelt.closest('.modal-deck-ignore').show();
 		var qty = '';
 		for(var i=0; i<=card.maxqty; i++) {


### PR DESCRIPTION
Modal fails to open for cards that have no traits, like Burn After Reading (1).