### PR TITLE
Remove dropping of sideSlots when API is used

### DIFF
--- a/src/AppBundle/Controller/Oauth2Controller.php
+++ b/src/AppBundle/Controller/Oauth2Controller.php
@@ -593,7 +593,6 @@ class Oauth2Controller extends Controller
 		$sideSlots = false;
 		if($request->get('side')) {
 			$sideSlots = (array) json_decode($request->get('side'));
-			$sideSlots = [];
 			if (count($sideSlots)) {
 				foreach($sideSlots as $card_code => $qty) {
 					// type-juggling means codes that don't start with 0 become integers.


### PR DESCRIPTION
Looks like the API supports this, except for this one line that inadvertently deletes the side deck if the 'side' field is ever used.

Changes removes that to fix this issue.