### PR TITLE
Add xp_spent to response deck API

### DIFF
--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -10,8 +10,12 @@ class ExportableDeck
 		$sideSlots = $this->getSideSlots();
 		$previousDeck = $this->getPreviousDeck();
 		$nextDeck = $this->getNextDeck();
+		$xp_spent = null;
 		if ($previousDeck){
 			$previousDeck = $previousDeck->getId();
+			if (method_exists($this, "getXpSpent")){
+				$xp_spent = $this->getXpSpent();
+			}
 		}else {
 			$previousDeck = null;
 		}
@@ -52,6 +56,7 @@ class ExportableDeck
 			'ignoreDeckLimitSlots' => $slots->getIgnoreDeckLimitContent(),
 			'version' => $this->getVersion(),
 			'xp' => $xp,
+			'xp_spent' => $xp_spent,
 			'xp_adjustment' => $xp_adjustment,
 			'exile_string' => $this->getExiles(),
 			'taboo_id' => $this->getTaboo() ? $this->getTaboo()->getId() : null,


### PR DESCRIPTION
API for saving only sets this when you save a deck that is part of an upgrade sequence, so this does the same on read-back.

Allows clients to avoid recalculating how much XP was spent, which is a fairly complex operation.