### PR TITLE
Deck building tags

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -475,6 +475,7 @@ class ImportStdCommand extends ContainerAwareCommand
 					'illustrator',
 					'flavor',
 					'traits',
+					'tags',
 					'text',
 					'customization_text',
 					'customization_change',

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -44,7 +44,8 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 				'myriad',
 				'errata_date',
 				'customization_text',
-				'customization_change'
+				'customization_change',
+				'tags'
 		];
 
 		$externalFields = [

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -392,12 +392,15 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	 */
 	private $traits;
 
-
 	/**
 	 * @var string
 	 */
 	private $realTraits;
 
+	/**
+	 * @var string
+	 */
+	private $tags;
 
 	/**
 	 * @var string
@@ -1537,6 +1540,30 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 	public function getTraits()
 	{
 		return $this->traits;
+	}
+
+	/**
+	 * Get tags
+	 *
+	 * @return string
+	 */
+	public function getTags()
+	{
+		return $this->tags;
+	}
+
+	/**
+	 * Set traits
+	 *
+	 * @param string $tags
+	 *
+	 * @return Card
+	 */
+	public function setTags($tags)
+	{
+		$this->tags = $tags;
+
+		return $this;
 	}
 
 	/**

--- a/src/AppBundle/Helper/DeckValidationHelper.php
+++ b/src/AppBundle/Helper/DeckValidationHelper.php
@@ -199,15 +199,14 @@ class DeckValidationHelper
 					}
 				}
 
-				if (isset($option->text) && $option->text) {
-					// needs to match at least one type
-					$text_valid = false;
-					foreach($option->text as $text) {
-						if (preg_match( "/".$text."/", strtolower($card->getRealText()) ) === 1){
-							$text_valid = true;
+				if (isset($option->tag) && $option->tag) {
+					$tag_valid = false;
+					foreach($option->tag as $tag) {
+						if (strpos(strtoupper($card->getTags()), strtoupper($tag)."." ) !== false){
+							$tag_valid = true;
 						}
 					}
-					if (!$text_valid){
+					if (!$tag_valid){
 						continue;
 					}
 				}

--- a/src/AppBundle/Resources/config/doctrine/Card.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Card.orm.yml
@@ -258,6 +258,10 @@ AppBundle\Entity\Card:
             type: string
             length: 255
             nullable: true
+        tags:
+            type: string
+            length: 255
+            nullable: true
         deckRequirements:
             type: string
             length: 255

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -1260,6 +1260,8 @@ deck.get_copies_and_deck_limit = function get_copies_and_deck_limit() {
 			deck_limit = 1;
 		} else if(typeof card.real_text !== 'undefined' && card.real_text.indexOf('Myriad.') !== -1) {
 			deck_limit = 3;
+		} else if (card.code === '08114' || card.code === '08115') {
+			deck_limit = 2;
 		}
 
 		if(!value) {
@@ -1655,6 +1657,26 @@ deck.can_include_card = function can_include_card(card, options) {
 				}
 			}
 
+			if (option.tag){
+				// needs to match at least one trait
+				var trait_valid = false;
+
+				for(var j = 0; j < option.tag.length; j++){
+					var trait = option.tag[j];
+
+					if (
+						(card.tags && card.tags.toUpperCase().indexOf(tag.toUpperCase()+".") !== -1) ||
+						(selected_customizations.length && _.find(selected_customizations, function(c) { return c.tags && c.tags.toUpperCase().indexOf(tag.toUpperCase()+".") !== -1; }))
+					) {
+						tag_valid = true;
+					}
+				}
+
+				if (!tag_valid){
+					continue;
+				}
+			}
+
 			if (option.uses){
 				// needs to match at least one trait
 				var uses_valid = false;
@@ -1671,26 +1693,6 @@ deck.can_include_card = function can_include_card(card, options) {
 				}
 
 				if (!uses_valid){
-					continue;
-				}
-
-			}
-
-			if (option.text){
-				// match a regular custom expression on the text
-				var text_valid = false;
-
-				for(var j = 0; j < option.text.length; j++){
-					var text = option.text[j];
-					if (
-						(card.real_text && card.real_text.toLowerCase().match(text)) ||
-						(selected_customizations.length && _.find(selected_customizations, function(c) { return c.real_text && c.real_text.toLowerCase().match(text); }))
-					){
-						text_valid = true;
-					}
-				}
-
-				if (!text_valid){
 					continue;
 				}
 


### PR DESCRIPTION
Adds new nullable column to hold tags on each 'card'

Corresponding change will make vincent + carolyn use this for deckbuilding.
Stops use of the .text field, so we can maintain backwards compatibility in the API by leaving the old field there for now.