### PR TITLE
Some corrections for object constructor

### DIFF
--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -280,23 +280,30 @@ deck.parse_customizations = function(card, entry) {
 		return [];
 	}
 	var lines = (card.customization_text || '').split('\n');
-	return _.map(entry.split(','), function(value) {
+	var values = entry.split(',');
+	var customizations = [];
+	for (var i = 0; i < values.length; i++) {
+		var value = values[i];
 		var parts = value.split('|');
-		var index = parseInt(parts[0]);
-		var xp = parseInt(parts[1]);
-		var option = card.customization_options[index] || {};
-		var result = {
-			index,
-			xp,
-			unlocked: !option.xp || (option && option.xp === xp),
-			option,
-			line: lines[index] || '',
-		};
-		if (parts.length > 2) {
-			result.choice = parts[2];
+		// Defensive programming against malformed input.
+		if (parts.length > 1 && parts[0] && parts[1] && parts[0] !== 'NaN' && parts[1] !== 'NaN') {
+			var index = parseInt(parts[0]);
+			var xp = parseInt(parts[1]);
+			var option = card.customization_options[index] || {};
+			var result = {
+				index: index,
+				xp: xp,
+				unlocked: !option.xp || (option && option.xp === xp),
+				option: option,
+				line: lines[index] || '',
+			};
+			if (parts.length > 2) {
+				result.choice = parts[2];
+			}
+			customizations.push(result);
 		}
-		return result;
-	});
+	}
+	return customizations;
 }
 
 /**
@@ -1267,7 +1274,7 @@ deck.get_copies_and_deck_limit = function get_copies_and_deck_limit() {
 		if(!value) {
 			copies_and_deck_limit[card.real_name] = {
 				nb_copies: card.indeck - card.ignore,
-				deck_limit
+				deck_limit: deck_limit,
 			};
 		} else {
 			value.nb_copies += card.indeck - card.ignore;

--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -922,11 +922,11 @@ ui.on_customization_change = function on_customization_change(card_code, index, 
 	var option = (card.customization_options && card.customization_options[index]) || {};
 	var unlocked = option.xp === xp;
 	var new_entry = {
-		index,
-		xp,
-		option,
-		choice,
-		unlocked,
+		index: index,
+		xp: xp,
+		option: option,
+		choice: choice,
+		unlocked: unlocked,
 		line: (card.customization_text && card.customization_text.split("\n")[index]) || '',
 	}
 
@@ -947,7 +947,7 @@ ui.on_customization_change = function on_customization_change(card_code, index, 
 	app.deck.meta['cus_' + card_code] = app.deck.encode_customizations(customizations);
 
 	if (option.deck_limit) {
-		var update = {customizations};
+		var update = {customizations: customizations};
 		update.maxqty = unlocked ? option.deck_limit : card.deck_limit;
 		card.maxqty = update.maxqty;
 		if (card.indeck) {
@@ -957,7 +957,7 @@ ui.on_customization_change = function on_customization_change(card_code, index, 
 		}
 		app.data.cards.updateById(card_code, update);
 	} else {
-		app.data.cards.updateById(card_code, {customizations});
+		app.data.cards.updateById(card_code, {customizations: customizations});
 	}
 	card.customizations = customizations.sort(function(a, b) {
 		return a.index - b.index;


### PR DESCRIPTION
The JS minifier was improperly minimizing code that was using object assignment in this form:
```
var foo = 'a string';
var object = { foo };
```
It would use minified variables in the object (o, a, b, etc), which caused later accesses of said variables to fail.

Also harden the parsing of the customizations somewhat against malformed data that the above bug might have introduced.