### PR TITLE
Make slots change when customizations are chosen

### DIFF
--- a/src/AppBundle/Resources/public/js/app.data.js
+++ b/src/AppBundle/Resources/public/js/app.data.js
@@ -253,32 +253,35 @@ data.apply_taboos = function apply_taboos(taboo_id){
 		var parsed_taboo = JSON.parse(taboo.cards);
 		parsed_taboo.forEach(function (taboo_card){
 			//console.log(taboo_card);
+			var og_card = app.data.cards.findOne({'code':taboo_card.code});
+			var cards = app.data.cards.find({'duplicate_of_code':taboo_card.code});
+			cards.push(og_card);
+			cards.forEach(function (card){
+				var update = {'taboo': true};
+				if (taboo_card.exceptional){
+					update.exceptional = true;
+					update.taboo_exceptional = true;
+				} else if (taboo_card.exceptional === false) {
+					update.exceptional = false;
+					update.taboo_remove_exceptional = true;
+				}
 
-			var card = app.data.cards.findOne({'code':taboo_card.code});
-			var update = {'taboo': true};
-			if (taboo_card.exceptional){
-				update.exceptional = true;
-				update.taboo_exceptional = true;
-			} else if (taboo_card.exceptional === false) {
-				update.exceptional = false;
-				update.taboo_remove_exceptional = true;
-			}
-
-			if (taboo_card.deck_options) {
-				update.taboo_deck_options = card.deck_options;
-				update.deck_options = taboo_card.deck_options;
-			}
-			if (taboo_card.deck_requirements) {
-				update.taboo_deck_requirements = card.deck_requirements;
-				update.deck_requirements = taboo_card.deck_requirements;
-			}
-			if (taboo_card.xp){
-				update.taboo_xp = taboo_card.xp;
-			}
-			if (taboo_card.text){
-				update.taboo_text = taboo_card.text;
-			}
-			app.data.cards.updateById(card.code, update);
+				if (taboo_card.deck_options) {
+					update.taboo_deck_options = card.deck_options;
+					update.deck_options = taboo_card.deck_options;
+				}
+				if (taboo_card.deck_requirements) {
+					update.taboo_deck_requirements = card.deck_requirements;
+					update.deck_requirements = taboo_card.deck_requirements;
+				}
+				if (taboo_card.xp){
+					update.taboo_xp = taboo_card.xp;
+				}
+				if (taboo_card.text){
+					update.taboo_text = taboo_card.text;
+				}
+				app.data.cards.updateById(card.code, update);
+			});
 		});
 	}
 }

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -1011,8 +1011,34 @@ deck.get_layout_data_one_section = function get_layout_data_one_section(query, d
 
 			cards.forEach(function (card) {
 				var $div = deck.create_card(card);
-				if (card.real_slot && slots[card.real_slot]){
-					slots[card.real_slot].push($div);
+				if (card.real_slot) {
+					var real_slot = card.real_slot;
+					if (card.customizations) {
+						for (var i=0; i<card.customizations.length; i++) {
+							var custom = card.customizations[i];
+							var option = custom.option;
+							if (custom.unlocked) {
+								if (option.choice === 'remove_slot') {
+									var choice = parseInt(custom.choice || '0', 10) || 0;
+									var real_slots = real_slot.split('.');
+									var new_slots = [];
+									for (let j=0; j<real_slots.length; j++) {
+										if (j !== choice) {
+											new_slots.push(real_slots[j].trim());
+										}
+									}
+									real_slot = new_slots.join('. ');
+								} else if (option.real_slot) {
+									real_slot = option.real_slot;
+								}
+							}
+						}
+					}
+					if (slots[real_slot]){
+						slots[real_slot].push($div);
+					} else {
+						slots["Other"].push($div);
+					}
 				} else {
 					slots["Other"].push($div);
 				}

--- a/src/AppBundle/Resources/public/js/app.deck_history.js
+++ b/src/AppBundle/Resources/public/js/app.deck_history.js
@@ -258,9 +258,9 @@ deck_history.all_changes = function all_changes() {
 			addition.qty = 0;
 		} else if (addition_xp >= 0){
 			while (addition.qty > 0 && addition.card.xp === 0 && (free_customize_swaps[addition.code] || 0) > 0) {
-				// Still have to pay taboo XP.
-				cost = cost + addition_xp;
-				free_customize_swaps[addition.code] = free_customize_swaps[addition.code] - 1;
+				// Still have to pay taboo XP and DTR_XP, but customizations lets you swap in cards for free
+				// without paying min 1 cost, per the FAQ
+				cost = cost + dtr_xp + addition_xp;
 				addition.qty = addition.qty - 1;
 			}
 			if (addition.qty > 0 && addition.card.xp === 0 && removed_0_cards > 0 && free_0_cards > 0){

--- a/src/AppBundle/Resources/public/js/app.deck_history.js
+++ b/src/AppBundle/Resources/public/js/app.deck_history.js
@@ -287,7 +287,8 @@ deck_history.all_changes = function all_changes() {
 			if (addition.card.indeck - addition.qty > 0 && addition.card.ignore) {
 				addition.card.ignore = addition.card.ignore - (addition.card.indeck - addition.qty);
 			}
-			cost = cost + ((dtr_xp + Math.max(addition_xp, 1)) * (addition.qty - addition.card.ignore));
+			// Down the Rabbit Hole satisfiest the minimum 1 XP cost when swapping in cards.
+			cost = cost + ((dtr_xp > 0 ? (dtr_xp + addition_xp) : Math.max(addition_xp, 1)) * (addition.qty - addition.card.ignore));
 			addition.qty = 0;
 		}
 	});

--- a/src/AppBundle/Resources/public/js/app.deck_history.js
+++ b/src/AppBundle/Resources/public/js/app.deck_history.js
@@ -187,9 +187,11 @@ deck_history.all_changes = function all_changes() {
 						upgradeCost--;
 						spell_upgrade_discounts--;
 					}
-					if (upgradeCost > 0 && upgrade_discounts > 0) {
-						upgradeCost--;
-						upgrade_discounts--;
+					for (var i = 0; i < upgraded_count; i++) {
+						if (upgradeCost > 0 && upgrade_discounts > 0) {
+							upgradeCost--;
+							upgrade_discounts--;
+						}
 					}
 					cost = cost + upgradeCost;
 				} else {

--- a/src/AppBundle/Resources/public/js/app.deck_history.js
+++ b/src/AppBundle/Resources/public/js/app.deck_history.js
@@ -81,6 +81,11 @@ deck_history.all_changes = function all_changes() {
 			free_0_cards += 5;
 			removed_0_cards += 5;
 		}
+		// underworld market
+		else if (card_change.code == "09077") {
+			free_0_cards += 10;
+			removed_0_cards += 10;
+		}
 	});
 
 	// find deja vu

--- a/src/AppBundle/Resources/public/js/app.deck_upgrades.js
+++ b/src/AppBundle/Resources/public/js/app.deck_upgrades.js
@@ -66,6 +66,11 @@ deck_upgrades.display = function display() {
 				free_0_cards += 5;
 				removed_0_cards += 5;
 			}
+			// underworld market
+			else if (card_change.code == "09077") {
+				free_0_cards += 10;
+				removed_0_cards += 10;
+			}
 		});
 		_.each(result[2], function(choices, code) {
 			var card = app.data.cards.findById(code);

--- a/src/AppBundle/Resources/public/js/app.deck_upgrades.js
+++ b/src/AppBundle/Resources/public/js/app.deck_upgrades.js
@@ -185,9 +185,11 @@ deck_upgrades.display = function display() {
 							upgradeCost--;
 							spell_upgrade_discounts--;
 						}
-						if (upgradeCost > 0 && upgrade_discounts > 0) {
-							upgradeCost--;
-							upgrade_discounts--;
+						for (var i = 0; i < upgraded_count; i++) {
+							if (upgradeCost > 0 && upgrade_discounts > 0) {
+								upgradeCost--;
+								upgrade_discounts--;
+							}
 						}
 						cost = cost + upgradeCost;
 					} else {

--- a/src/AppBundle/Resources/public/js/app.deck_upgrades.js
+++ b/src/AppBundle/Resources/public/js/app.deck_upgrades.js
@@ -279,7 +279,7 @@ deck_upgrades.display = function display() {
 			if (addition.card.indeck - addition.qty > 0 && addition.card.ignore) {
 				addition.card.ignore = addition.card.ignore - (addition.card.indeck - addition.qty);
 			}
-			cost = cost + ((dtr_xp + Math.max(addition_xp, 1)) * (addition.qty - addition.card.ignore));
+			cost = cost + ((dtr_xp > 0 ? (dtr_xp + addition_xp) : Math.max(addition_xp, 1)) * (addition.qty - addition.card.ignore));
 			addition.qty = 0;
 		}
 	});

--- a/src/AppBundle/Resources/public/js/app.deck_upgrades.js
+++ b/src/AppBundle/Resources/public/js/app.deck_upgrades.js
@@ -248,10 +248,10 @@ deck_upgrades.display = function display() {
 			cost = cost + deja_vu_cost + dtr_xp;
 			addition.qty = 0;
 		} else if (addition_xp >= 0){
-			while (addition.qty > 0 && (free_customize_swaps[addition.code] || 0) > 0) {
-				// Still have to pay taboo XP.
-				cost = cost + addition_xp;
-				free_customize_swaps[addition.code] = free_customize_swaps[addition.code] - 1;
+			while (addition.qty > 0 && addition.card.xp === 0 && (free_customize_swaps[addition.code] || 0) > 0) {
+				// Still have to pay taboo XP and DTR_XP, but customizations lets you swap in cards for free
+				// without paying min 1 cost, per the FAQ
+				cost = cost + dtr_xp + addition_xp;
 				addition.qty = addition.qty - 1;
 			}
 			if (addition.qty > 0 && addition.card.xp === 0 && removed_0_cards > 0 && free_0_cards > 0){

--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -208,16 +208,20 @@ format.slot = function slot(card) {
 		for (var i=0; i<card.customizations.length; i++) {
 			var custom = card.customizations[i];
 			var option = custom.option;
-			if (custom.unlocked && option.choice === 'remove_slot') {
-				var choice = parseInt(custom.choice || '0', 10) || 0;
-				var slots = slot.split('.');
-				var new_slots = [];
-				for (let j=0; j<slots.length; j++) {
-					if (j !== choice) {
-						new_slots.push(slots[j].trim());
+			if (custom.unlocked) {
+				if (option.choice === 'remove_slot') {
+					var choice = parseInt(custom.choice || '0', 10) || 0;
+					var slots = slot.split('.');
+					var new_slots = [];
+					for (let j=0; j<slots.length; j++) {
+						if (j !== choice) {
+							new_slots.push(slots[j].trim());
+						}
 					}
+					slot = new_slots.join('. ');
+				} else if (option.real_slot && slot_names) {
+					slot = slot_names[option.real_slot];
 				}
-				slot = new_slots.join('. ');
 			}
 		}
 	}

--- a/src/AppBundle/Resources/public/js/ui.deckedit.js
+++ b/src/AppBundle/Resources/public/js/ui.deckedit.js
@@ -1273,7 +1273,7 @@ ui.update_list_template = function update_list_template() {
 				+ '</td>'
 				+ '<td class="xp"><%= card.xp %></td>'
 				+ '<td class="cost"><%= card.cost %></td>'
-				+ '<td class="type" style="text-align : left;"><span class="" title="<%= card.type_name %>"><%= card.type_name %></span> <% if (card.slot) { %> - <%= card.slot %> <% } %></td>'
+				+ '<td class="type" style="text-align : left;"><span class="" title="<%= card.type_name %>"><%= card.type_name %></span> <% if (card.slot) { %> - <%= app.format.slot(card) %> <% } %></td>'
 				+ '<td class="faction"><span class="fg-<%= card.faction_code %>" title="<%= card.faction_name %>"><%= card.faction_name %></span></td>'
 			+ '</tr>'
 		);

--- a/src/AppBundle/Resources/views/Builder/deckedit.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deckedit.html.twig
@@ -6,6 +6,16 @@
 	<script src="{{ asset_url }}"></script>
 	{% endjavascripts %}
 	<script type="text/javascript">
+	var slot_names = {
+		'Accessory': '{% trans %}Accessory{% endtrans %}',
+		'Body': '{% trans %}Body{% endtrans %}',
+		'Arcane': '{% trans %}Arcane{% endtrans %}',
+		'Arcane x2': '{% trans %}Arcane x2{% endtrans %}',
+		'Hand': '{% trans %}Hand{% endtrans %}',
+		'Hand x2': '{% trans %}Hand x2{% endtrans %}',
+		'Ally': '{% trans %}Ally{% endtrans %}',
+		'Tarot': '{% trans %}Tarot{% endtrans %}',
+	};
 	app.deck && app.deck.init({{ deck|json_encode|raw }}, {{ deck.previousDeck ? deck.previousDeck.meta|raw : ''}});
 	$( document ).ready(function() {
 		app.deck_history && app.deck_history.init({{ deck.history|json_encode|raw }}, {{ deck.previousDeck ? deck.previousDeck.meta|raw : ''}});

--- a/src/AppBundle/Resources/views/Builder/deckview.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deckview.html.twig
@@ -6,6 +6,16 @@
 	<script src="{{ asset_url }}"></script>
 	{% endjavascripts %}
 	<script type="text/javascript">
+	var slot_names = {
+		'Accessory': '{% trans %}Accessory{% endtrans %}',
+		'Body': '{% trans %}Body{% endtrans %}',
+		'Arcane': '{% trans %}Arcane{% endtrans %}',
+		'Arcane x2': '{% trans %}Arcane x2{% endtrans %}',
+		'Hand': '{% trans %}Hand{% endtrans %}',
+		'Hand x2': '{% trans %}Hand x2{% endtrans %}',
+		'Ally': '{% trans %}Ally{% endtrans %}',
+		'Tarot': '{% trans %}Tarot{% endtrans %}',
+	};
 	app.deck && app.deck.init({{ deck|json_encode|raw }});
 	app.deck_history && app.deck_history.init({{ deck.history|json_encode|raw }}, {{ deck.previousDeck ? deck.previousDeck.meta|raw : ''}});
 

--- a/src/AppBundle/Resources/views/Search/card-info.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-info.html.twig
@@ -1,4 +1,4 @@
 <div class="card-info{% if card.spoiler is defined and not show_spoilers %} spoiler{% endif %}" >
-	<span class="card-type">{{ card.type_name }}{% if card.stage %}. Stage {{card.stage}}{% endif %}{% if card.slot %}. {{card.slot}}{% endif %}{% if card.subtype_name is defined %}. {{card.subtype_name}}{% endif %}</span>
+	<span class="card-type">{{ card.type_name }}{% if card.stage %}. Stage {{card.stage}}{% endif %}{% if card.slot %}. {{app.format.slot(slot)}}{% endif %}{% if card.subtype_name is defined %}. {{card.subtype_name}}{% endif %}</span>
 	{% include 'AppBundle:Search:card-props.html.twig' %}
 </div>


### PR DESCRIPTION
Requires setting up new translation tables to localize the slot names, when editing/viewing decks.
The test on this localization is conditional though, if the global `slot_names` is not present, it simply skips the operation.

- Also fixes XP calculation issue reported in: https://github.com/Kamalisk/arkhamdb/issues/566