### PR TITLE
Add import for key type

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -787,6 +787,11 @@ class ImportStdCommand extends ContainerAwareCommand
 
 	}
 
+	protected function importKeyData(Card $card, $data)
+	{
+
+	}
+
 	protected function importInvestigatorData(Card $card, $data)
 	{
 		$mandatoryKeys = [


### PR DESCRIPTION
Just need an empty function to keep the import script working with the new card type.