### PR TITLE
Fix the styling of the oauth flow page

### DIFF
--- a/app/Resources/FOSOAuthServerBundle/views/Authorize/authorize_content.html.twig
+++ b/app/Resources/FOSOAuthServerBundle/views/Authorize/authorize_content.html.twig
@@ -1,0 +1,40 @@
+{% extends 'AppBundle::layout.html.twig' %}
+
+{% block navbar %}{% endblock %}
+
+{% block body %}
+<div class="container">
+	<div class="row">
+		<div class="col-md-6 col-md-offset-3">
+			<div class="panel panel-default">
+				<div class="panel-heading">
+					<h3 class="panel-title" style="line-height:2em">Grant access to your account?</h3>
+				</div>
+				<div class="panel-body">
+					<div class="form">
+						<p>The application "{{ client.name }}" would like to connect to your account.</p>
+                        <p>If you choose to grant access, this application will be able to take the following actions on your behalf:</p>
+                        <ul>
+                            <li>Read decks you have created.</li>
+                            <li>Create and modify your decks.</li>
+                            <li>Delete decks from your account.</li>
+                        </ul>
+                        <p>Would you like to approve this access?</p>
+
+						{{ form_start(form, {method: 'POST', action: path('fos_oauth_server_authorize'), label_attr: {class: 'fos_oauth_server_authorize'} }) }}
+                            <input class="btn btn-primary" type="submit" name="accepted" value="{{ 'authorize.accept'|trans({}, 'FOSOAuthServerBundle') }}" />
+                            <input class="btn btn-default"  type="submit" name="rejected" value="{{ 'authorize.reject'|trans({}, 'FOSOAuthServerBundle') }}" />
+                            {{ form_row(form.client_id) }}
+                            {{ form_row(form.response_type) }}
+                            {{ form_row(form.redirect_uri) }}
+                            {{ form_row(form.state) }}
+                            {{ form_row(form.scope) }}
+                        {{ form_end(form) }}
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+{% endblock %}
+{% block footer %}{% endblock %}


### PR DESCRIPTION
Modeled after the login page, but with the content replaced to include the form.  Tested it locally, it seems to work just fine.

<img width="351" alt="Screen Shot 2022-12-07 at 3 00 42 PM" src="https://user-images.githubusercontent.com/1091291/206283432-4e3f2f4c-82cc-468f-ace6-a57aa8f97982.png">

<img width="354" alt="Screen Shot 2022-12-07 at 3 11 00 PM" src="https://user-images.githubusercontent.com/1091291/206285375-6b4e5b14-4e4a-4423-97de-d9127fbae8d1.png">
