### PR TITLE
Fix discount on Down The Rabbit Hole

### DIFF
--- a/src/AppBundle/Resources/public/js/app.deck_history.js
+++ b/src/AppBundle/Resources/public/js/app.deck_history.js
@@ -182,9 +182,11 @@ deck_history.all_changes = function all_changes() {
 						upgradeCost--;
 						spell_upgrade_discounts--;
 					}
-					if (upgradeCost > 0 && upgrade_discounts > 0) {
-						upgradeCost--;
-						upgrade_discounts--;
+					for (var i = 0; i < upgraded_count; i++) {
+						if (upgradeCost > 0 && upgrade_discounts > 0) {
+							upgradeCost--;
+							upgrade_discounts--;
+						}
 					}
 					cost = cost + upgradeCost;
 				} else {


### PR DESCRIPTION
Discount from Down The Rabbit Hole was not applied properly when Arcane Research was also present in the deck and the two upgraded cards were of the same name. This fix now applies the discount to both copies.

Resolves #505 