### PR TITLE
Some languages don't use spaces

### DIFF
--- a/src/AppBundle/Resources/public/js/app.card_modal.js
+++ b/src/AppBundle/Resources/public/js/app.card_modal.js
@@ -329,7 +329,7 @@ function update_customizations(modal, card) {
 				}
 				if (card.maxqty) {
 					// Edit mode
-					line = line.replace(/□+ /, '');
+					line = line.replace(/□+\s?/, '');
 					customization_html += '<div style="display:flex; flex-direction: row; align-items:flex-start;' + (!option.xp ? ' margin-left: 8px;' : '') + '">';
 
 					for(var j=0; j<option.xp; j++) {


### PR DESCRIPTION
Make the space optional in the regex for customizations, got report that it was broken in chinese language.