### PR TITLE
Fix deck validation for 5U-21

### DIFF
--- a/src/AppBundle/Helper/DeckValidationHelper.php
+++ b/src/AppBundle/Helper/DeckValidationHelper.php
@@ -224,7 +224,18 @@ class DeckValidationHelper
 						}
 					}
 				}
-
+				
+				if(isset($option->permanent) && $option->permanent) {
+					error_log(print_r($deck_options, true));
+					$permanent_valid = false;
+					//Not permanent and not Ravenous
+					if ($card->getPermanent() == $option->permanent && $card->getCode() != 89002) {
+						$permanent_valid = true;
+					} else {
+						continue;
+					}
+				} 
+				
 				if (isset($option->not) && $option->not){
 					return false;
 				}else {

--- a/src/AppBundle/Helper/DeckValidationHelper.php
+++ b/src/AppBundle/Helper/DeckValidationHelper.php
@@ -226,7 +226,6 @@ class DeckValidationHelper
 				}
 				
 				if(isset($option->permanent) && $option->permanent) {
-					error_log(print_r($deck_options, true));
 					$permanent_valid = false;
 					//Not permanent and not Ravenous
 					if ($card->getPermanent() == $option->permanent && $card->getCode() != 89002) {


### PR DESCRIPTION
Suzi has a deck validation problem but it seems just to be an issue that there's no check for the "permanent" type like all the other types, so it just goes to the "not" check which of course it is a "not permanent"  check so it automatically fails.

I just added a check for permanent and everything is fine. Of course I had to put an exception for her signature.