### PR TITLE
Preserve user input when decklist comment fails to post

### DIFF
--- a/src/AppBundle/Resources/public/css/style.css
+++ b/src/AppBundle/Resources/public/css/style.css
@@ -459,6 +459,10 @@ div.site-slogan {
 #deck-description h4 {
 	font-size: 107%;
 }
+#comment-alert {
+	margin-top: 20px;
+}
+
 
 /************** FACTIONS COLORS **************/
 .bg-faction a, .bg-faction span {

--- a/src/AppBundle/Resources/public/js/ui.decklist.js
+++ b/src/AppBundle/Resources/public/js/ui.decklist.js
@@ -92,11 +92,13 @@
 				data: data,
 				type: 'POST',
 				success: function(data, textStatus, jqXHR) {
-					form.replaceWith('<div class="alert alert-success" role="alert">Your comment has been posted. It will appear on the site in a few minutes.</div>');
+					form.remove();
+					$('#comment-alert').empty().append('<div class="alert alert-success" role="alert">Your comment has been posted. It will appear on the site in a few minutes.</div>');
 				},
 				error: function(jqXHR, textStatus, errorThrown) {
 					console.log('['+moment().format('YYYY-MM-DD HH:mm:ss')+'] Error on '+this.url, textStatus, errorThrown);
-					form.replaceWith('<div class="alert alert-danger" role="alert">An error occured while posting your comment ('+jqXHR.statusText+'). Reload the page and try again.</div>');
+					$('#comment-alert').empty().append('<div class="alert alert-danger" role="alert">An error occured while posting your comment ('+jqXHR.statusText+').</div>');
+					already_submitted = false;
 				}
 			});
 		});

--- a/src/AppBundle/Resources/views/Decklist/comments.html.twig
+++ b/src/AppBundle/Resources/views/Decklist/comments.html.twig
@@ -21,3 +21,4 @@
 </tbody>
 </table>
 <a id="comment-form"></a>
+<div id="comment-alert" />


### PR DESCRIPTION
Currently, if you attempt to post a comment on a decklist, your form is replaced regardless of whether or not the post was successful. This means you lose your input if there is a problem, which is frustrating.

- This PR updates the logic to preserve the user's form, so they can either copy their draft somewhere else and try again later, or try again immediately.
- Some alert text has been changed to reflect that there is no longer a need to refresh the page.

![image](https://github.com/Kamalisk/arkhamdb/assets/250171/a0edc76e-fcda-449e-92c9-e239e244e39d)

NB: Other forms on the site, such as the Card Review and Review Comment forms, do not exhibit this behavior and do not need to be changed.

#### Related issues:
https://github.com/Kamalisk/arkhamdb/issues/651