### PR TITLE
Add rules reference text for Elusive and Patrol

### DIFF
--- a/src/AppBundle/Resources/views/Default/rulesreference.html.twig
+++ b/src/AppBundle/Resources/views/Default/rulesreference.html.twig
@@ -189,7 +189,8 @@
 	<li><a href="#Nested_Skill_Tests">Nested Skill Tests</a></li>
 	<li><a href="#Ownership_and_Control">Ownership and Control</a></li>
 	<li><a href="#Parley">Parley</a></li>
-	<li><a href="#Partner">Partner</a></li>	
+	<li><a href="#Partner">Partner</a></li>
+	<li><a href="#Patrol">Patrol</a></li>
 	<li><a href="#Per_Investigator">Per Investigator</a></li>
 	<li><a href="#Peril">Peril</a></li>
 	<li><a href="#Permanent">Permanent</a></li>
@@ -2222,6 +2223,18 @@
 <li> Damage or horror on a partner asset is recorded in the Expedition Team section of the Campaign Log at the end of each game. <i>(The Campaign Guide will instruct you when to do this.)</i></li>
 
 <li> If an investigator resigns from a scenario, their partner asset leaves play, but is not defeated. Keep all damage and horror on it, as it will be recorded in the Campaign Log after the game ends.</li>
+
+</ul>
+
+<h2 id="Patrol" style="color:red">Patrol (added in <em>Murder at the Excelsior Hotel</em>)</h2>
+
+<p>Some enemies have the patrol keyword. During the enemy phase (in framework step 3.2), each ready, unengaged enemy with the patrol keyword moves to a connecting location along the shortest path toward the designated location (as described in parentheses next to the word patrol).
+
+<ul>
+
+<li> If there are multiple locations that qualify as the desginated location, the lead investigator may choose which location the enemy moves toward.</li>
+
+<li> If an enemy with patrol would be compelled to move to a location which is blocked by a card ability, the enemy does not move.</li>
 
 </ul>
 

--- a/src/AppBundle/Resources/views/Default/rulesreference.html.twig
+++ b/src/AppBundle/Resources/views/Default/rulesreference.html.twig
@@ -113,6 +113,7 @@
 	<li><a href="#Drawing_Cards">Drawing Cards</a></li>
 	<li><a href="#Effects">Effects</a></li>
 	<li><a href="#Elimination">Elimination</a></li>
+	<li><a href="#Elusive">Elusive</a></li>
 	<li><a href="#Empty_Location">Empty Location</a></li>
 	<li><a href="#Encounter_Cards_Vs_Scenario_Cards">"Encounter Cards" vs "Scenario Cards"</a></li>
 	<li><a href="#Encounter_Deck">Encounter Deck</a></li>

--- a/src/AppBundle/Resources/views/Default/rulesreference.html.twig
+++ b/src/AppBundle/Resources/views/Default/rulesreference.html.twig
@@ -1388,6 +1388,18 @@
 
 </ol>
 
+<h2 id="Elusive">Elusive (added in <em>The Feast of Hemlock Vale</em>)</h2>
+
+<p>Elusive is a keyword ability that appears on some enemies in this expansion. Elusive enemies represent enemies who want to avoid the investigators for their own survival or to accomplish their own goals.</p>
+
+<p>If a ready enemy with the elusive keyword attacks or is attacked, after that attack resolves, that enemy immediately disengages from all investigators, moves to a connecting location (with no investigators if able), and exhausts.</p>
+
+<ul>
+
+<li>  This effect occurs whether the enemy was engaged with the attacking investigator or not.</li>
+
+</ul>
+
 <h2 id="Empty_Location">Empty Location</h2>
 
 <p>An empty location is a location with no enemies or investigators at it.</p>

--- a/src/AppBundle/Resources/views/Default/rulesreference.html.twig
+++ b/src/AppBundle/Resources/views/Default/rulesreference.html.twig
@@ -1388,7 +1388,7 @@
 
 </ol>
 
-<h2 id="Elusive">Elusive (added in <em>The Feast of Hemlock Vale</em>)</h2>
+<h2 id="Elusive" style="color:red">Elusive (added in <em>The Feast of Hemlock Vale</em>)</h2>
 
 <p>Elusive is a keyword ability that appears on some enemies in this expansion. Elusive enemies represent enemies who want to avoid the investigators for their own survival or to accomplish their own goals.</p>
 


### PR DESCRIPTION
Elusive is a new rule in FHV. This PR adds the text of the rule as printed in the Investigator Expansion rules insert. 

Also adds Patrol. Murder at the Excelsior Hotel was the earliest standalone I found it in, so that's what I wrote in the header. But I could change it to Hemlock Vale if we want to limit this to campaigns.