### PR TITLE
fix: check `permanent` equality

### DIFF
--- a/src/AppBundle/Helper/DeckValidationHelper.php
+++ b/src/AppBundle/Helper/DeckValidationHelper.php
@@ -143,6 +143,11 @@ class DeckValidationHelper
 			return false;
 		}
 
+		if ($card->getFaction()->getCode() === "mythos") {
+			return false;
+		}
+
+		// reject cards restricted
 		$investigator = $deck->getCharacter();
 		$restrictions = $card->getRestrictions();
 		if ($restrictions){
@@ -150,6 +155,19 @@ class DeckValidationHelper
 			if ($parsed && $parsed['investigator'] && !isset($parsed['investigator'][$investigator->getCode()]) ){
 				return false;
 			}
+		}
+
+		// always allow the required cards regardless
+		$requirements = $investigator->getDeckRequirements();
+		if ($requirements) {
+			$parsed = $this->parseReqString($requirements);
+			if ($parsed && $parsed['card'] && $parsed['card'][$card->getCode()]) {
+				return true;
+			}
+		}
+
+		if ($card->getDeckLimit() > 0 && is_null($card->getXp())) {
+			return true;
 		}
 
 		// allow any 2 random faction cards for now
@@ -236,14 +254,8 @@ class DeckValidationHelper
 					}
 				}
 
-				if(isset($option->permanent) && $option->permanent) {
-					$permanent_valid = false;
-					//Not permanent and not Ravenous
-					if ($card->getPermanent() == $option->permanent && $card->getCode() != 89002) {
-						$permanent_valid = true;
-					} else {
-						continue;
-					}
+				if(isset($option->permanent) && $card->getPermanent() != $option->permanent) {
+					continue;
 				}
 
 				if (isset($option->not) && $option->not){

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -1553,6 +1553,11 @@ deck.can_include_card = function can_include_card(card, options) {
 		}
 	}
 
+	// always allow weaknesses and story assets
+	if (card.deck_limit > 0 && card.xp == null) {
+		return true;
+	}
+
 	var real_slot = card.real_slot && card.real_slot.toUpperCase();
 
 	var selected_customizations = [];
@@ -1653,10 +1658,8 @@ deck.can_include_card = function can_include_card(card, options) {
 				}
 			}
 
-			if (option.permanent){
-				if (card.permanent !== option.permanent){
-					continue;
-				}
+			if (option.permanent != null && card.permanent !== option.permanent) {
+				continue;
 			}
 
 			if (option.slot){


### PR DESCRIPTION
this fixes a few things:
- allows checking `permanent: false` for https://github.com/Kamalisk/arkhamdb-json-data/pull/1415
- fixes Suzi not being able to take story permanents such as `Poisoned`

I changed the top validation logic in two ways:
- always allow `xp=null` cards that are not restricted to other investigators
- add missing check for required cards in php logic