### PR TITLE
feat: support `type: enemy_location`

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -767,7 +767,7 @@ class ImportStdCommand extends ContainerAwareCommand
 				$this->links[] = ['card_id'=> $entity->getCode(), 'target_id'=> $data['alternate_of'], 'type' => 'alternate_of'];
 			}
 			// calling a function whose name depends on the type_code
-			$functionName = 'import' . $entity->getType()->getName() . 'Data';
+			$functionName = 'import' . str_replace("-", "", $entity->getType()->getName()) . 'Data';
 			$this->$functionName($entity, $data);
 		}
 
@@ -862,6 +862,20 @@ class ImportStdCommand extends ContainerAwareCommand
 		}
 	}
 
+	protected function importEnemyLocationData(Card $card, $data)
+	{
+		$mandatoryKeys = [
+			'shroud',
+			'clues',
+			'enemy_fight',
+			'enemy_evade',
+			'health'
+		];
+
+		foreach($mandatoryKeys as $key) {
+			$this->copyKeyToEntity($card, 'AppBundle\Entity\Card', $data, $key, TRUE);
+		}
+	}
 
 	protected function importEventData(Card $card, $data)
 	{

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -124,6 +124,19 @@ class Card implements \Gedmo\Translatable\Translatable, \Serializable
 				$optionalFields[] = 'health_per_investigator';
 				$optionalFields[] = 'encounter_position';
 				break;
+			case "enemy_location":
+				$optionalFields[] = 'clues_fixed';
+				$optionalFields[] = 'clues';
+				$optionalFields[] = 'encounter_position';
+				$optionalFields[] = 'enemy_damage';
+				$optionalFields[] = 'enemy_evade';
+				$optionalFields[] = 'enemy_fight';
+				$optionalFields[] = 'enemy_horror';
+				$optionalFields[] = 'health_per_investigator';
+				$optionalFields[] = 'health';
+				$optionalFields[] = 'shroud';
+				$optionalFields[] = 'victory';
+				break;
 			case "location":
 				$optionalFields[] = 'victory';
 				$optionalFields[] = 'vengeance';

--- a/src/AppBundle/Resources/public/js/app.format.js
+++ b/src/AppBundle/Resources/public/js/app.format.js
@@ -126,13 +126,26 @@ format.info = function info(card) {
 			text += '<div>Clues: '+format.fancy_int(card.clues)+'.</div>';
 			break;
 		case 'location':
-			if (card.clues_fixed || card.clues == 0){
+			if (card.clues_fixed || !card.clues){
 				text += '<div>Shroud: '+format.fancy_int(card.shroud)+'. Clues: '+format.fancy_int(card.clues)+'.</div>';
 			} else {
 				text += '<div>Shroud: '+format.fancy_int(card.shroud)+'. Clues: '+format.fancy_int(card.clues)+'<span class="icon icon-per_investigator"></span>.</div>';
 			}
 			break;
 		case 'enemy':
+			text += '<div>Fight: '+format.fancy_int(card.enemy_fight)+'. Health: '+format.fancy_int(card.health)+'';
+			if (card.health_per_investigator){
+				text += '<span class="icon icon-per_investigator"></span>';
+			}
+			text += '. Evade: '+format.fancy_int(card.enemy_evade)+'.</div>';
+			text += '<div>Damage: '+format.fancy_int(card.enemy_damage)+'. Horror: '+format.fancy_int(card.enemy_horror)+'.</div>';
+			break;
+		case 'enemy_location':
+			if (card.clues_fixed || !card.clues){
+				text += '<div>Shroud: '+format.fancy_int(card.shroud)+'. Clues: '+format.fancy_int(card.clues)+'.</div>';
+			} else {
+				text += '<div>Shroud: '+format.fancy_int(card.shroud)+'. Clues: '+format.fancy_int(card.clues)+'<span class="icon icon-per_investigator"></span>.</div>';
+			}
 			text += '<div>Fight: '+format.fancy_int(card.enemy_fight)+'. Health: '+format.fancy_int(card.health)+'';
 			if (card.health_per_investigator){
 				text += '<span class="icon icon-per_investigator"></span>';

--- a/src/AppBundle/Resources/views/Search/card-props.html.twig
+++ b/src/AppBundle/Resources/views/Search/card-props.html.twig
@@ -58,7 +58,14 @@
 			{% trans %}Sanity{% endtrans %}: {{ macros.integer_or_x(card.sanity) }}.
 			</div>
 		{% endif %}
-		{% elseif card.type_code == 'enemy' %}
+		{% elseif card.type_code == 'enemy' or card.type_code == 'enemy_location' %}
+			{% if card.clues is not null or card.shroud %}
+			<div>
+			{% if card.shroud %}<span title="Shroud" class="icon icon-shroud color-shroud"></span>{% trans %}Shroud{% endtrans %}: {{macros.integer_or_x(card.shroud)}}.{% endif %}
+			{% if card.clues %}<span title="Clues" class="icon icon-clues color-clues"></span>{% trans %}Clues{% endtrans %}: {{card.clues}}{% if not card.clues_fixed %}<span class="icon icon-per_investigator" title="Per Investigator"></span>{% endif %}.{% endif %}
+			{% if card.clues == 0 %}<span title="Clues" class="icon icon-clues color-clues"></span>{% trans %}Clues{% endtrans %}: {% if card.clues is null %}&ndash;{% else %}{{card.clues}}{% endif %}{% endif %}
+			</div>
+			{% endif %}
 			<div>
 			{% trans %}Fight{% endtrans %}: {{ macros.integer_or_x(card.enemy_fight) }}.
 			{% trans %}Health{% endtrans %}: {{ macros.integer_or_x(card.health) }}{% if card.health_per_investigator %}<span class="icon icon-per_investigator"></span>{% endif %}.


### PR DESCRIPTION
This adds support for the new `enemy_location` card type introduced in FHV. See: https://github.com/zzorba/arkhamdb-json-data/pull/14

⚠️ In order for this to work, a new entry has to be added to the `type` database table:

```js
{ 
  code: "enemy_location",
  name: "Enemy-Location"
}
```

I don't know if there is a seed for this somewhere, I did not find it.

Additionally, this PR fixes a small issue with the JS card templates where `clues: null` would render as `- [per_investigator]`.  