### PR TITLE
fix: remove inconsistent limit for `meta` on `DeckChange` table

### DIFF
--- a/src/AppBundle/Resources/config/doctrine/Deckchange.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Deckchange.orm.yml
@@ -27,7 +27,6 @@ AppBundle\Entity\Deckchange:
             length: 1024
         meta:
             type: string
-            length: 1024
             nullable: true
         isSaved:
             type: boolean


### PR DESCRIPTION
⚠️ This change does nothing by itself, it would have to be reflected in the database.

Right now, the size of the `meta` column is inconsistent between `Deck` and `DeckChange`:
- For `Deck` it's a `longtext` field without any limits
- For `DeckChange` it is limited to `1024` characters

When a deck is first saved, this limits the size of the deck's meta to effectively `1024` characters. Subsequent saves don't have this limitation, because no `DeckChange` is created. I'm not sure what the intended / correct limit is here - 1kb or  limit of `longtext`?
