### PR TITLE
Fix inconsistencies with Seeker Agatha

### DIFF
--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -64,9 +64,13 @@ class BuilderController extends Controller
 
 				$investigator->setDeckRequirements($req);
 
-				// only have one investigator per name
-				if (!isset($all_unique_investigators[$investigator->getName()])) {
-					$all_unique_investigators[$investigator->getName()] = true;
+				// only have one investigator per faction and name
+				$investigator_key = preg_replace(
+					"/[^A-Za-z0-9 ]/", '', sprintf('%s (%s)', $investigator->getName(), $investigator->getFaction()->getName())
+				);
+
+				if (!isset($all_unique_investigators[$investigator_key])) {
+					$all_unique_investigators[$investigator_key] = true;
 					if (!isset($all_investigators_by_class[$investigator->getFaction()->getName()]) ) {
 						$all_investigators_by_class[$investigator->getFaction()->getName()] = [];
 					}
@@ -90,11 +94,11 @@ class BuilderController extends Controller
 						}
 					}
 
-					$all_investigators[preg_replace("/[^A-Za-z0-9 ]/", '', $investigator->getName())] = $investigator;
+					$all_investigators[$investigator_key] = $investigator;
 					$classes[$investigator->getFaction()->getName()] = $investigator->getFaction()->getName();
 				} else {
 					// investigator already present, but check for owner on the new version
-					$original = $all_investigators[preg_replace("/[^A-Za-z0-9 ]/", '', $investigator->getName())];
+					$original = $all_investigators[$investigator_key];
 					if (in_array($investigator->getPack()->getId(), $packs_owned) ){
 						$original->owned = 1;
 					}

--- a/src/AppBundle/Helper/DeckValidationHelper.php
+++ b/src/AppBundle/Helper/DeckValidationHelper.php
@@ -79,10 +79,14 @@ class DeckValidationHelper
 							break;
 						}
 						case "investigator":{
+							if (!isset($return_requirements[$type])) {
+								$return_requirements[$type] = [];
+							}
 							if ($param2){
-								$return_requirements[$type] = [$param1 => $param1, $param2 => $param2];
+								$return_requirements[$type][$param1] = $param1;
+								$return_requirements[$type][$param2] = $param2;
 							}else if ($param1){
-								$return_requirements[$type] = [$param1 => $param1];
+								$return_requirements[$type][$param1] = $param1;
 							}
 							break;
 						}


### PR DESCRIPTION
closes #704
closes #706

> [!WARNING]
> My confidence in my PHP code is low, please review this accordingly. I tested the changes locally and everything seems to work, but please also check.

This PR contains two separate changes that together make the newly released Agatha Crane work:

1. Relax the "one investigator per name" condition to "one investigator per faction and name" on the "choose investigator" page. Now both versions of Agatha show up.
2. Change the investigator `restrictions` parser to support multiple investigators: `"restrictions": "investigator:11007, investigator:11008"`. Now Seeker Agatha can take the shared signatures. This fix also propagates to the frontend validation library via the cards_api route once the cache is cleared, no further changes are required there.

The second change results in a two line change to the data returned by the cards data API:

```
diff --git a/b.json b/a.json
index 70fb4aa..0d60220 100644
--- a/b.json
+++ b/a.json
@@ -190571,6 +190571,7 @@
     "real_traits": "Item. Tool. Science.",
     "restrictions": {
       "investigator": {
+        "11007": "11007",
         "11008": "11008"
       }
     },
@@ -190605,6 +190606,7 @@
     "real_traits": "Blunder. Insight.",
     "restrictions": {
       "investigator": {
+        "11007": "11007",
         "11008": "11008"
       }
     },
(END)
```