### PR TITLE
Update icons.css

### DIFF
--- a/src/AppBundle/Resources/public/css/icons.css
+++ b/src/AppBundle/Resources/public/css/icons.css
@@ -73,16 +73,16 @@
 	content: "1";
 }
 .icon-seal_b:before {
-	content: "=2";
+	content: "4";
 }
 .icon-seal_c:before {
 	content: "3";
 }
 .icon-seal_d:before {
-	content: "4";
+	content: "5";
 }
 .icon-seal_e:before {
-	content: "5";
+	content: "2";
 }
 .icon-auto_fail:before {
 	content: "m";


### PR DESCRIPTION
`seal_b`, `seal_d`, and `seal_e` render out of order whenever they appear on ArkhamDB (an outstanding example of this is https://arkhamdb.com/card/08662). In addition, the definition of `seal_b` contained a stray `=` that also causes improper rendering; see also that same above-linked card.

Please feel free to edit this as needed; this is only what I *think* is the correct fix.